### PR TITLE
Set magazine viewer scales to 1

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -9,8 +9,8 @@ import { Pagination } from "@/components/ui/pagination"
 
 const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false })
 
-const CLOSED_SCALE = 1.2
-const OPEN_SCALE = 1.2
+const CLOSED_SCALE = 1
+const OPEN_SCALE = 1
 const INITIAL_POS = { x: 0, y: 0 }
 
 interface Page {


### PR DESCRIPTION
## Summary
- Normalize magazine viewer zoom constants to scale content from baseline of 1.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8658d7d483248a85dd86bb560404