### PR TITLE
Fix zoom centering in magazine viewer

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -91,7 +91,10 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
     const container = containerRef.current
     if (!container) return
     const rect = container.getBoundingClientRect()
-    const center = new DOMPoint(rect.width / 2, rect.height / 2)
+    const center = new DOMPoint(
+      rect.width / 2 - offsetX - translate.x,
+      rect.height / 2 - translate.y,
+    )
     zoomAtPoint(center, scale + delta)
   }
 


### PR DESCRIPTION
## Summary
- Zoom around the visible center by compensating for offset and current translation in magazine viewer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*
- `npm run build` *(fails: Failed to fetch `Open Sans` and `Montserrat` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5c8fb0848324abcdb479ca43b8e5