### PR TITLE
center zoom on book in magazine viewer

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -88,11 +88,11 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
   )
 
   const zoom = (delta: number) => {
-    const container = containerRef.current
-    if (!container) return
-    const rect = container.getBoundingClientRect()
-    const center = new DOMPoint(rect.width / 2, rect.height / 2)
-    zoomAtPoint(center, scale + delta)
+    const bookCenter = new DOMPoint(
+      offsetX + translate.x + pageWidth / 2,
+      translate.y + pageHeight / 2
+    )
+    zoomAtPoint(bookCenter, scale + delta)
   }
 
   const zoomIn = () => zoom(0.1)


### PR DESCRIPTION
## Summary
- use book center rather than container center for zoom calculations

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: interactive ESLint configuration prompt)

------
https://chatgpt.com/codex/tasks/task_e_68ac95dccee48324be0f9f22986055c3