### PR TITLE
feat: add edge click zones for magazine viewer

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -274,13 +274,14 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         maxShadowOpacity={0.2}
         className="shadow-md"
         ref={bookRef}
-          onFlip={handleFlip}
-            style={{
-              transform: `translate(${offsetX + translate.x}px, ${translate.y}px) scale(${scale})`,
-              transition: isDragging ? "none" : "transform 0.3s ease",
-              transformOrigin: "0 0",
-            }}
-        >
+        clickToFlip={false}
+        onFlip={handleFlip}
+        style={{
+          transform: `translate(${offsetX + translate.x}px, ${translate.y}px) scale(${scale})`,
+          transition: isDragging ? "none" : "transform 0.3s ease",
+          transformOrigin: "0 0",
+        }}
+      >
         {pages.map((page) => (
           <div
             key={page.id}
@@ -290,6 +291,15 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
           </div>
         ))}
       </HTMLFlipBook>
+
+      <div
+        className="absolute inset-y-0 left-0 w-[10%] cursor-pointer"
+        onClick={handlePrevPage}
+      />
+      <div
+        className="absolute inset-y-0 right-0 w-[10%] cursor-pointer"
+        onClick={handleNextPage}
+      />
 
       <Button
         variant="ghost"


### PR DESCRIPTION
## Summary
- disable global page flip click by setting `clickToFlip={false}`
- add left/right overlay divs to flip pages when clicked

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68acd7b4d62c832491b22cde6877b84e