### PR TITLE
feat: add navigation zones

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -272,15 +272,15 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         height={pageHeight}
         showCover
         maxShadowOpacity={0.2}
-        className="shadow-md"
+        className="shadow-md pointer-events-none"
         ref={bookRef}
-          onFlip={handleFlip}
-            style={{
-              transform: `translate(${offsetX + translate.x}px, ${translate.y}px) scale(${scale})`,
-              transition: isDragging ? "none" : "transform 0.3s ease",
-              transformOrigin: "0 0",
-            }}
-        >
+        onFlip={handleFlip}
+        style={{
+          transform: `translate(${offsetX + translate.x}px, ${translate.y}px) scale(${scale})`,
+          transition: isDragging ? "none" : "transform 0.3s ease",
+          transformOrigin: "0 0",
+        }}
+      >
         {pages.map((page) => (
           <div
             key={page.id}
@@ -290,6 +290,15 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
           </div>
         ))}
       </HTMLFlipBook>
+
+      <div
+        className="absolute top-0 left-0 h-full w-[10%]"
+        onClick={handlePrevPage}
+      />
+      <div
+        className="absolute top-0 right-0 h-full w-[10%]"
+        onClick={handleNextPage}
+      />
 
       <Button
         variant="ghost"


### PR DESCRIPTION
## Summary
- add left/right overlay zones for page navigation
- disable default flip interaction on central book

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ace48b98f4832483ed2db6d6a38920