### PR TITLE
Disable flipbook mouse events when zoomed

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -277,12 +277,13 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         disableFlipByClick
         className="shadow-md"
         ref={bookRef}
-          onFlip={handleFlip}
-            style={{
-              transform: `translate(${offsetX + translate.x}px, ${translate.y}px) scale(${scale})`,
-              transition: isDragging ? "none" : "transform 0.3s ease",
-              transformOrigin: "0 0",
-            }}
+        useMouseEvents={scale <= OPEN_SCALE}
+        onFlip={handleFlip}
+        style={{
+          transform: `translate(${offsetX + translate.x}px, ${translate.y}px) scale(${scale})`,
+          transition: isDragging ? "none" : "transform 0.3s ease",
+          transformOrigin: "0 0",
+        }}
         >
         {pages.map((page) => (
           <div


### PR DESCRIPTION
## Summary
- avoid mouse flip interactions in magazine viewer when zoomed in

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68acefc0b8a483248c2d3035176f694e