### PR TITLE
feat: add page navigation on first and last pages

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -284,14 +284,25 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
               transformOrigin: "0 0",
             }}
         >
-        {pages.map((page) => (
-          <div
-            key={page.id}
-            className="w-full h-full bg-white overflow-hidden shadow-md"
-          >
-            {page.content}
-          </div>
-        ))}
+        {pages.map((page, index) => {
+          const isFirst = index === 0
+          const isLast = index === totalPages - 1
+
+          return (
+            <div
+              key={page.id}
+              className={`w-full h-full bg-white overflow-hidden shadow-md ${
+                isFirst || isLast ? "cursor-pointer" : ""
+              }`}
+              onClick={() => {
+                if (isFirst) handleNextPage()
+                else if (isLast) handlePrevPage()
+              }}
+            >
+              {page.content}
+            </div>
+          )
+        })}
       </HTMLFlipBook>
 
       <Button


### PR DESCRIPTION
## Summary
- detect first and last magazine pages
- add click handlers for first and last pages and cursor pointer styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acf26dd600832490c957eae1207b43