### PR TITLE
feat: add fullscreen toggle button

### DIFF
--- a/components/fullscreen-button.tsx
+++ b/components/fullscreen-button.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Maximize2, Minimize2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export function FullScreenButton() {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  useEffect(() => {
+    const handleChange = () => setIsFullscreen(Boolean(document.fullscreenElement))
+    document.addEventListener("fullscreenchange", handleChange)
+    return () => document.removeEventListener("fullscreenchange", handleChange)
+  }, [])
+
+  const toggleFullscreen = async () => {
+    if (!document.fullscreenElement) {
+      await document.documentElement.requestFullscreen()
+    } else {
+      await document.exitFullscreen()
+    }
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleFullscreen}
+      className="bg-transparent hover:bg-white/10 text-white/70 hover:text-white border-none w-16 h-16 transition-all duration-300"
+    >
+      {isFullscreen ? (
+        <Minimize2 className="h-8 w-8" />
+      ) : (
+        <Maximize2 className="h-8 w-8" />
+      )}
+    </Button>
+  )
+}
+

--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -6,6 +6,7 @@ import { Plus, Minus, ChevronLeft, ChevronRight } from "lucide-react"
 import dynamic from "next/dynamic"
 import { Button } from "@/components/ui/button"
 import { Pagination } from "@/components/ui/pagination"
+import { FullScreenButton } from "@/components/fullscreen-button"
 import type { default as FlipBook } from "react-pageflip"
 
 const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false })
@@ -331,6 +332,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
       </div>
 
       <div className="absolute bottom-4 right-4 flex flex-col gap-2 items-end">
+        <FullScreenButton />
         <Button
           variant="ghost"
           size="icon"


### PR DESCRIPTION
## Summary
- add reusable `FullScreenButton` component using the Fullscreen API
- integrate `FullScreenButton` into `MagazineViewer` toolbar for easy fullscreen toggling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ada729cb00832488b830ac201670ad