### PR TITLE
feat: enhance flipbook page animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -194,3 +194,18 @@
 .transition-all {
   transition: all 0.3s ease;
 }
+
+/* Custom flipbook page styling */
+.flipbook .stf__item {
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+}
+
+.flipbook .stf__item > div {
+  backface-visibility: hidden;
+  transition: transform var(--flip-duration, 700ms) ease;
+}
+
+/* Slight delay for the back face to simulate page thickness */
+.flipbook .stf__item > div:nth-child(2) {
+  transition-delay: 0.1s;
+}

--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -13,6 +13,7 @@ const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false })
 const CLOSED_SCALE = 1
 const OPEN_SCALE = 1
 const INITIAL_POS = { x: 0, y: 0 }
+const FLIP_DURATION = 700
 
 interface Page {
   id: number
@@ -273,17 +274,21 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         height={pageHeight}
         showCover
         maxShadowOpacity={0.2}
+        drawShadow
+        flippingTime={FLIP_DURATION}
         showPageCorners
         disableFlipByClick
-        className="shadow-md"
+        swipeDistance={30}
+        className="shadow-md flipbook"
         ref={bookRef}
-          onFlip={handleFlip}
-            style={{
-              transform: `translate(${offsetX + translate.x}px, ${translate.y}px) scale(${scale})`,
-              transition: isDragging ? "none" : "transform 0.3s ease",
-              transformOrigin: "0 0",
-            }}
-        >
+        onFlip={handleFlip}
+        style={{
+          transform: `translate(${offsetX + translate.x}px, ${translate.y}px) scale(${scale})`,
+          transition: isDragging ? "none" : "transform 0.3s ease",
+          transformOrigin: "0 0",
+          ["--flip-duration" as any]: `${FLIP_DURATION}ms`,
+        }}
+      >
         {pages.map((page, index) => {
           const isFirst = index === 0
           const isLast = index === totalPages - 1


### PR DESCRIPTION
## Summary
- add configurable flip duration and shadow rendering
- style pages with box shadows and delayed back face

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint configuration prompt)

------
https://chatgpt.com/codex/tasks/task_e_68ada7326218832493bcebadd2b182dc