### PR TITLE
Add overlay button to portfolio page 17

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -72,9 +72,9 @@ const bjornChapterPages = [
         >
           <Button
             variant="outline"
-            className="absolute bottom-10 right-10 z-10 border-white text-white hover:bg-white hover:text-black"
+            className="absolute bottom-10 left-1/2 -translate-x-1/2 z-10 border-gray-400 text-gray-700 bg-white/90 hover:bg-gray-100"
           >
-            Visiter le site
+            visiter le site
           </Button>
         </Link>
       </div>

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -1,5 +1,7 @@
 import Head from "next/head"
 import Image, { type ImageProps } from "next/image"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
 import fs from "fs"
 import path from "path"
 
@@ -63,6 +65,18 @@ const bjornChapterPages = [
           className="object-cover"
           unoptimized
         />
+        <Link
+          href="https://www.figma.com/proto/NITAGZXbWhIXvS86y4oytS/Site-Web-MBAT?page-id=0%3A1&node-id=176-9725&viewport=777%2C-291%2C0.31&t=QTx62eY5jD6B6o68-8&scaling=scale-down-width&content-scaling=fixed&hide-ui=1"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Button
+            variant="outline"
+            className="absolute bottom-10 right-10 z-10 border-white text-white hover:bg-white hover:text-black"
+          >
+            Visiter le site
+          </Button>
+        </Link>
       </div>
     ),
   },


### PR DESCRIPTION
## Summary
- add `Visiter le site` button linking to Figma prototype on page 17
- import `Button` and `Link` for overlay navigation

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68ae25924ba48324af44756d62e02ea9