### PR TITLE
feat: add Sora font and style portfolio button

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import type { Metadata } from "next"
 import { Montserrat } from "next/font/google"
 import { Open_Sans } from "next/font/google"
+import { Sora } from "next/font/google"
 import "./globals.css"
 
 const montserrat = Montserrat({
@@ -18,6 +19,12 @@ const openSans = Open_Sans({
   weight: ["400", "500", "600"],
 })
 
+const sora = Sora({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-sora",
+})
+
 export const metadata: Metadata = {
   title: "COFFRE Elliott - Portfolio 2025",
   description:
@@ -31,7 +38,10 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" className={`${montserrat.variable} ${openSans.variable} antialiased`}>
+    <html
+      lang="en"
+      className={`${montserrat.variable} ${openSans.variable} ${sora.variable} antialiased`}
+    >
       <body className="font-sans">{children}</body>
     </html>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,6 +23,7 @@ const sora = Sora({
   subsets: ["latin"],
   display: "swap",
   variable: "--font-sora",
+  weight: ["400"],
 })
 
 export const metadata: Metadata = {

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -1,7 +1,6 @@
 import Head from "next/head"
 import Image, { type ImageProps } from "next/image"
 import Link from "next/link"
-import { Button } from "@/components/ui/button"
 import fs from "fs"
 import path from "path"
 
@@ -69,13 +68,9 @@ const bjornChapterPages = [
           href="https://www.figma.com/proto/NITAGZXbWhIXvS86y4oytS/Site-Web-MBAT?page-id=0%3A1&node-id=176-9725&viewport=777%2C-291%2C0.31&t=QTx62eY5jD6B6o68-8&scaling=scale-down-width&content-scaling=fixed&hide-ui=1"
           target="_blank"
           rel="noopener noreferrer"
+          className="absolute bottom-10 left-1/2 -translate-x-1/2 z-10 bg-[#D9D9D9] text-black font-sora px-4 py-2 w-full max-w-[200px] text-center"
         >
-          <Button
-            variant="outline"
-            className="absolute bottom-10 left-1/2 -translate-x-1/2 z-10 border-gray-400 text-gray-700 bg-white/90 hover:bg-gray-100"
-          >
-            visiter le site
-          </Button>
+          visiter le site
         </Link>
       </div>
     ),

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -68,7 +68,7 @@ const bjornChapterPages = [
           href="https://www.figma.com/proto/NITAGZXbWhIXvS86y4oytS/Site-Web-MBAT?page-id=0%3A1&node-id=176-9725&viewport=777%2C-291%2C0.31&t=QTx62eY5jD6B6o68-8&scaling=scale-down-width&content-scaling=fixed&hide-ui=1"
           target="_blank"
           rel="noopener noreferrer"
-          className="absolute bottom-10 left-1/2 -translate-x-1/2 z-10 bg-[#D9D9D9] text-black font-sora px-4 py-2 w-full max-w-[200px] text-center"
+          className="absolute z-10 bg-[#D9D9D9] text-black font-sora text-base font-normal w-[260px] h-[48px] flex items-center justify-center left-10 bottom-12"
         >
           visiter le site
         </Link>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -121,3 +121,9 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .font-sora {
+    font-family: var(--font-sora);
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -125,5 +125,6 @@
 @layer utilities {
   .font-sora {
     font-family: var(--font-sora);
+    font-weight: 400;
   }
 }


### PR DESCRIPTION
## Summary
- load Sora font globally with next/font and expose `font-sora` utility
- style portfolio page 17 link to match design

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run lint` *(interactive prompt prevents completion)*
- `npm run build` *(fails: Failed to fetch Google Fonts files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2ba35fbc832486332bf1b81f381a