### PR TITLE
feat: highlight book buttons after page flip

### DIFF
--- a/components/book-button.tsx
+++ b/components/book-button.tsx
@@ -5,11 +5,16 @@ import { cn } from "@/lib/utils"
 import { useHighlightButtons } from "./highlight-buttons-context"
 import type { ComponentProps } from "react"
 
-export function BookButton({ className, ...props }: ComponentProps<typeof Button>) {
+export function BookButton({
+  className,
+  disabled,
+  ...props
+}: ComponentProps<typeof Button>) {
   const highlightButtons = useHighlightButtons()
   return (
     <Button
       className={cn(className, highlightButtons && "grayscale pointer-events-none")}
+      disabled={disabled || highlightButtons}
       {...props}
     />
   )

--- a/components/book-button.tsx
+++ b/components/book-button.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { useHighlightButtons } from "./highlight-buttons-context"
+import type { ComponentProps } from "react"
+
+export function BookButton({ className, ...props }: ComponentProps<typeof Button>) {
+  const highlightButtons = useHighlightButtons()
+  return (
+    <Button
+      className={cn(className, highlightButtons && "grayscale pointer-events-none")}
+      {...props}
+    />
+  )
+}

--- a/components/fullscreen-button.tsx
+++ b/components/fullscreen-button.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { Maximize2, Minimize2 } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { BookButton } from "@/components/book-button"
 
 export function FullScreenButton() {
   const [isFullscreen, setIsFullscreen] = useState(false)
@@ -22,7 +22,7 @@ export function FullScreenButton() {
   }
 
   return (
-    <Button
+    <BookButton
       variant="ghost"
       size="icon"
       onClick={toggleFullscreen}
@@ -33,7 +33,7 @@ export function FullScreenButton() {
       ) : (
         <Maximize2 className="h-8 w-8" />
       )}
-    </Button>
+    </BookButton>
   )
 }
 

--- a/components/highlight-buttons-context.ts
+++ b/components/highlight-buttons-context.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from "react"
+
+export const HighlightButtonsContext = createContext(true)
+
+export function useHighlightButtons() {
+  return useContext(HighlightButtonsContext)
+}

--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -4,9 +4,10 @@ import type React from "react"
 import { useState, useRef, useEffect, useCallback } from "react"
 import { Plus, Minus, ChevronLeft, ChevronRight } from "lucide-react"
 import dynamic from "next/dynamic"
-import { Button } from "@/components/ui/button"
 import { Pagination } from "@/components/ui/pagination"
 import { FullScreenButton } from "@/components/fullscreen-button"
+import { BookButton } from "@/components/book-button"
+import { HighlightButtonsContext } from "./highlight-buttons-context"
 import type { default as FlipBook } from "react-pageflip"
 
 const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false })
@@ -34,6 +35,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
   const [translate, setTranslate] = useState(INITIAL_POS)
   const [isDragging, setIsDragging] = useState(false)
   const lastPointer = useRef(INITIAL_POS)
+  const [highlightButtons, setHighlightButtons] = useState(true)
 
   const totalPages = pages.length
   const PAGE_WIDTH = 500
@@ -184,6 +186,12 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
     }
   }, [handleWheel])
 
+  useEffect(() => {
+    setHighlightButtons(true)
+    const timeout = setTimeout(() => setHighlightButtons(false), 2000)
+    return () => clearTimeout(timeout)
+  }, [currentPage])
+
   // Handle touch gestures for mobile
   useEffect(() => {
     const container = containerRef.current
@@ -258,18 +266,19 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
   }, [scale, zoomAtPoint])
 
   return (
-    <div
-      ref={containerRef}
-      className="relative w-full h-screen overflow-hidden flex items-center justify-center p-4"
-      style={{ backgroundColor: "#0E0E0E" }}
-      onMouseDown={handleMouseDown}
-      onMouseMove={handleMouseMove}
-      onMouseUp={endDragging}
-      onMouseLeave={endDragging}
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={endDragging}
-    >
+    <HighlightButtonsContext.Provider value={highlightButtons}>
+      <div
+        ref={containerRef}
+        className="relative w-full h-screen overflow-hidden flex items-center justify-center p-4"
+        style={{ backgroundColor: "#0E0E0E" }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={endDragging}
+        onMouseLeave={endDragging}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={endDragging}
+      >
       <HTMLFlipBook
         width={pageWidth}
         height={pageHeight}
@@ -311,22 +320,22 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         })}
       </HTMLFlipBook>
 
-      <Button
+      <BookButton
         variant="ghost"
         size="icon"
         onClick={handlePrevPage}
         className="absolute top-1/2 left-4 -translate-y-1/2 bg-transparent hover:bg-white/10 text-white/70 hover:text-white border-none w-16 h-16 transition-all duration-300"
       >
         <ChevronLeft className="h-8 w-8" />
-      </Button>
-      <Button
+      </BookButton>
+      <BookButton
         variant="ghost"
         size="icon"
         onClick={handleNextPage}
         className="absolute top-1/2 right-4 -translate-y-1/2 bg-transparent hover:bg-white/10 text-white/70 hover:text-white border-none w-16 h-16 transition-all duration-300"
       >
         <ChevronRight className="h-8 w-8" />
-      </Button>
+      </BookButton>
 
       <div className="absolute bottom-4 left-4">
         <Pagination
@@ -338,23 +347,24 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
 
       <div className="absolute bottom-4 right-4 flex flex-col gap-2 items-end">
         <FullScreenButton />
-        <Button
+        <BookButton
           variant="ghost"
           size="icon"
           onClick={zoomIn}
           className="bg-transparent hover:bg-white/10 text-white/70 hover:text-white border-none w-16 h-16 transition-all duration-300"
         >
           <Plus className="h-8 w-8" />
-        </Button>
-        <Button
+        </BookButton>
+        <BookButton
           variant="ghost"
           size="icon"
           onClick={zoomOut}
           className="bg-transparent hover:bg-white/10 text-white/70 hover:text-white border-none w-16 h-16 transition-all duration-300"
         >
           <Minus className="h-8 w-8" />
-        </Button>
+        </BookButton>
       </div>
-    </div>
+      </div>
+    </HighlightButtonsContext.Provider>
   )
 }

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head"
 import Image, { type ImageProps } from "next/image"
 import Link from "next/link"
-import { Button } from "@/components/ui/button"
+import { BookButton } from "@/components/book-button"
 import fs from "fs"
 import path from "path"
 
@@ -70,12 +70,12 @@ const bjornChapterPages = [
           target="_blank"
           rel="noopener noreferrer"
         >
-          <Button
-            variant="outline"
+            <BookButton
+              variant="outline"
               className="absolute bottom-30 left-[51%] z-10 -translate-x-1/2 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
-          >
-            visiter le site
-          </Button>
+            >
+              visiter le site
+            </BookButton>
         </Link>
       </div>
     ),


### PR DESCRIPTION
## Summary
- add highlight button context and helper component
- gray out navigation and zoom controls for 2s after changing page
- reuse same highlight state for fullscreen and page link buttons

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: awaiting interactive ESLint configuration)
- `npm run build` (fails: Failed to fetch Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_68aefa63ec1c8324b52b56dbbccfa9e7