### PR TITLE
Add highlight button pulse animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -211,3 +211,20 @@
 .flipbook .stf__item > div:nth-child(2) {
   transition-delay: 0.1s;
 }
+
+/* Blue pulse animation for clickable book buttons */
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(59, 130, 246, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+  }
+}
+
+.book-clickable {
+  animation: pulse 2s ease-in-out 3;
+}

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -72,7 +72,8 @@ const bjornChapterPages = [
         >
           <Button
             variant="outline"
-              className="absolute bottom-30 left-[51%] z-10 -translate-x-1/2 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
+            highlight
+            className="absolute bottom-30 left-[51%] z-10 -translate-x-1/2 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
           >
             visiter le site
           </Button>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -27,10 +27,15 @@ const buttonVariants = cva(
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
       },
+      highlight: {
+        true: "book-clickable",
+        false: "",
+      },
     },
     defaultVariants: {
       variant: "default",
       size: "default",
+      highlight: false,
     },
   }
 )
@@ -39,6 +44,7 @@ function Button({
   className,
   variant,
   size,
+  highlight,
   asChild = false,
   ...props
 }: React.ComponentProps<"button"> &
@@ -50,7 +56,7 @@ function Button({
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(buttonVariants({ variant, size, highlight, className }))}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- add blue pulse animation and `.book-clickable` class
- extend Button with `highlight` variant
- highlight "visiter le site" button in portfolio pages

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68af07dcf42c83248cb796ecc1925200