### PR TITLE
feat: add pulsing background for highlighted buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -216,15 +216,19 @@
 @keyframes pulse {
   0% {
     box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7);
+    background-color: #fff;
   }
   70% {
     box-shadow: 0 0 0 10px rgba(59, 130, 246, 0);
+    background-color: #f3f4f6;
   }
   100% {
     box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+    background-color: #fff;
   }
 }
 
 .book-clickable {
+  background-color: #fff;
   animation: pulse 2s ease-in-out 3;
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -56,7 +56,14 @@ function Button({
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, highlight, className }))}
+      className={cn(
+        buttonVariants({
+          variant: highlight ? null : variant,
+          size,
+          highlight,
+          className,
+        })
+      )}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- animate book buttons with a grey background pulse
- ignore other variants when highlight is enabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68af0cc115cc83249fe560f58039c672