### PR TITLE
Use grey pulse backgrounds for clickable book buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -216,15 +216,19 @@
 @keyframes pulse {
   0% {
     box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7);
+    background-color: #f3f4f6;
   }
   70% {
     box-shadow: 0 0 0 10px rgba(59, 130, 246, 0);
+    background-color: #e5e7eb;
   }
   100% {
     box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+    background-color: #f3f4f6;
   }
 }
 
 .book-clickable {
+  background-color: #f3f4f6;
   animation: pulse 2s ease-in-out 3;
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -54,12 +54,12 @@ function Button({
   const Comp = asChild ? Slot : "button"
 
   return (
-    <Comp
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, highlight, className }))}
-      {...props}
-    />
-  )
-}
+      <Comp
+        data-slot="button"
+        className={cn(buttonVariants({ variant, size, highlight }), className)}
+        {...props}
+      />
+    )
+  }
 
 export { Button, buttonVariants }


### PR DESCRIPTION
## Summary
- Adjust pulse keyframes to animate between light and dark grey instead of white
- Give `.book-clickable` a light grey base background and ensure highlight variant keeps it

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68af250273dc8324bd142fc01cb38171