### PR TITLE
Add background pulse animation for highlight buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -216,15 +216,19 @@
 @keyframes pulse {
   0% {
     box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7);
+    background-color: #ffffff;
   }
   70% {
     box-shadow: 0 0 0 10px rgba(59, 130, 246, 0);
+    background-color: #f3f4f6;
   }
   100% {
     box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+    background-color: #ffffff;
   }
 }
 
 .book-clickable {
+  background-color: #ffffff;
   animation: pulse 2s ease-in-out 3;
 }

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -70,13 +70,13 @@ const bjornChapterPages = [
           target="_blank"
           rel="noopener noreferrer"
         >
-          <Button
-            variant="outline"
-            highlight
-            className="absolute bottom-30 left-[51%] z-10 -translate-x-1/2 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
-          >
-            visiter le site
-          </Button>
+            <Button
+              variant="outline"
+              highlight
+              className="absolute bottom-30 left-[51%] z-10 -translate-x-1/2 rounded-none border border-[#1C1C1C] px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
+            >
+              visiter le site
+            </Button>
         </Link>
       </div>
     ),

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -28,7 +28,7 @@ const buttonVariants = cva(
         icon: "size-9",
       },
       highlight: {
-        true: "book-clickable",
+        true: "book-clickable bg-white",
         false: "",
       },
     },
@@ -56,7 +56,7 @@ function Button({
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, highlight, className }))}
+      className={cn(buttonVariants({ variant, size, highlight }), className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- pulse keyframes now animate background color from white to gray and back
- highlight variant always uses `.book-clickable` with white base
- portfolio "visiter le site" button relies on highlight animation

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm dev` *(verified page served and contains highlight button)*

------
https://chatgpt.com/codex/tasks/task_e_68af27c5511883249421cfa032f9d3b3