### PR TITLE
Add grey tint to pulse animation for book button

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -214,16 +214,19 @@
 
 /* Blue pulse animation for clickable book buttons */
 @keyframes pulse {
-  0% {
-    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7);
+    0% {
+      box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7);
+      background-color: rgba(0, 0, 0, 0.05);
+    }
+    70% {
+      box-shadow: 0 0 0 10px rgba(59, 130, 246, 0);
+      background-color: rgba(0, 0, 0, 0.05);
+    }
+    100% {
+      box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+      background-color: transparent;
+    }
   }
-  70% {
-    box-shadow: 0 0 0 10px rgba(59, 130, 246, 0);
-  }
-  100% {
-    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
-  }
-}
 
 .book-clickable {
   animation: pulse 2s ease-in-out 3;


### PR DESCRIPTION
## Summary
- tint pulse animation with subtle grey background at start and mid phases
- clear tint at end of animation for .book-clickable

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Next.js lint requires interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_68af2afdf90c8324b651f1fa78aa9913