### PR TITLE
style: add gray highlight for book-clickable

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -227,4 +227,11 @@
 
 .book-clickable {
   animation: pulse 2s ease-in-out 3;
+  background-color: rgba(128, 128, 128, 0.5);
+  border: 1px solid rgba(128, 128, 128, 0.7);
+}
+
+.book-clickable:active {
+  background-color: rgba(128, 128, 128, 0.5);
+  border: 1px solid rgba(128, 128, 128, 0.7);
 }


### PR DESCRIPTION
## Summary
- add semi-transparent gray background and border for `.book-clickable` buttons

## Testing
- `npm test`
- `npm run lint` (fails: requires interactive ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68af2de58930832481f7216114ab391d