### PR TITLE
feat: add interactive styles for book buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -227,4 +227,21 @@
 
 .book-clickable {
   animation: pulse 2s ease-in-out 3;
+  background: white;
+  color: black;
+  border: 1px solid black;
+  transition: background-color 0.2s, filter 0.2s;
+}
+
+.book-clickable:hover {
+  background: black;
+  color: white;
+}
+
+.book-clickable:active {
+  filter: brightness(0.85);
+}
+
+.book-clickable:hover:active {
+  filter: brightness(1.15);
 }


### PR DESCRIPTION
## Summary
- style `.book-clickable` with white background, black text, border, and smooth transition effects
- add hover state to invert colors and active states to adjust brightness

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build` *(fails: Failed to fetch font files from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68af4695bc788324924adcd928906212