### PR TITLE
feat: gray pulse effect for book buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -212,25 +212,31 @@
   transition-delay: 0.1s;
 }
 
-/* Blue pulse animation for clickable book buttons */
+/* Gray pulse animation for clickable book buttons */
 @keyframes pulse {
   0% {
-    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.7);
+    box-shadow: 0 0 0 0 rgba(107, 114, 128, 0.7);
+    filter: grayscale(0);
   }
   70% {
-    box-shadow: 0 0 0 10px rgba(59, 130, 246, 0);
+    box-shadow: 0 0 0 10px rgba(107, 114, 128, 0);
+    filter: grayscale(1);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0);
+    box-shadow: 0 0 0 0 rgba(107, 114, 128, 0);
+    filter: grayscale(0);
   }
 }
 
 .book-clickable {
   animation: pulse 2s ease-in-out 3;
+  animation-fill-mode: forwards;
   background: white;
   color: black;
   border: 1px solid black;
   transition: background-color 0.2s, filter 0.2s;
+  position: relative;
+  overflow: hidden;
 }
 
 .book-clickable:hover {


### PR DESCRIPTION
## Summary
- replace blue pulse with gray and add grayscale peak
- ensure `.book-clickable` retains color during pulse

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68af7f0148848324b3741f34dc5bece5