### PR TITLE
Reduce book-clickable animation iterations

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -224,7 +224,7 @@
 }
 
 .book-clickable {
-  animation: blue-pulse 2s ease-in-out 3;
+  animation: blue-pulse 2s ease-in-out 2;
   background: white;
   color: black;
   border: 1px solid black;


### PR DESCRIPTION
## Summary
- shorten book-clickable animation to run twice instead of three times

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68af866c4d5483248b773c5f33a3de76