### PR TITLE
feat: use translucent blue for pulse animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -219,7 +219,7 @@
     background-color: white;
   }
   50% {
-    background-color: #3b82f6;
+    background-color: rgba(59,130,246,0.4);
   }
 }
 


### PR DESCRIPTION
## Summary
- use semi-transparent blue for the `blue-pulse` animation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68af8676f6f083248266e65efbdac268