### PR TITLE
Allow book animation to continue on hover

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -231,11 +231,6 @@
   transition: background-color 0.2s, filter 0.2s;
 }
 
-.book-clickable:hover,
-.book-clickable:active {
-  animation: none;
-}
-
 .book-clickable:hover {
   background: black;
   color: white;


### PR DESCRIPTION
## Summary
- remove CSS rule that stopped `.book-clickable` animation on hover/active

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b0235a8f088324acebd90ed14089ae