### PR TITLE
Reduce blue pulse animation opacity

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -219,7 +219,7 @@
     background-color: white;
   }
   50% {
-    background-color: rgba(59,130,246,0.4);
+    background-color: rgba(59,130,246,0.2);
   }
 }
 


### PR DESCRIPTION
## Summary
- make blue pulse animation more subtle by decreasing its opacity

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b0273ad02c8324929fd40a7650a273