### PR TITLE
Trigger button pulse on page 17

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -224,11 +224,14 @@
 }
 
 .book-clickable {
-  animation: blue-pulse 2s ease-in-out 2;
   background: white;
   color: black;
   border: 1px solid black;
   transition: background-color 0.2s, filter 0.2s;
+}
+
+.pulse-active {
+  animation: blue-pulse 2s ease-in-out 2;
 }
 
 .book-clickable:hover {

--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -257,6 +257,15 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
     }
   }, [scale, zoomAtPoint])
 
+  useEffect(() => {
+    const buttons = document.querySelectorAll(".book-clickable")
+    buttons.forEach((btn) => btn.classList.remove("pulse-active"))
+
+    if (currentPage + 1 === 17) {
+      buttons.forEach((btn) => btn.classList.add("pulse-active"))
+    }
+  }, [currentPage])
+
   return (
     <div
       ref={containerRef}


### PR DESCRIPTION
## Summary
- extract pulse animation from `.book-clickable` into new `.pulse-active` class
- monitor current page in magazine viewer to detect when page 17 is shown
- dynamically attach pulse animation to the call-to-action button when page 17 is visible

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next not found; npm install failed due to peer dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68b029c87814832484472fcf72fc2bec