### PR TITLE
fix: correct button alignment

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -73,7 +73,7 @@ const bjornChapterPages = [
           <Button
             variant="outline"
             highlight
-            className="absolute bottom-30 left-[51%] z-10 -translate-x-1/2 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
+            className="absolute bottom-[30px] left-1/2 z-10 -translate-x-1/2 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
           >
             visiter le site
           </Button>


### PR DESCRIPTION
## Summary
- replace nonstandard `bottom-30` with Tailwind `bottom-[30px]`
- center button horizontally with `left-1/2`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b029dd895c8324ad42d42c77bb64af