### PR TITLE
fix: disable cover corner skip

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -277,7 +277,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         maxShadowOpacity={0.2}
         drawShadow
         flippingTime={FLIP_DURATION}
-        showPageCorners
+        showPageCorners={false}
         disableFlipByClick
         swipeDistance={30}
         className="shadow-md flipbook"


### PR DESCRIPTION
## Summary
- disable HTMLFlipBook page corner interactions to avoid double page flips on the cover

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: Failed to fetch `Montserrat` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b02efa4a648324b6d9d723d2a9fcdb