### PR TITLE
refactor image preloading

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,6 +35,18 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${montserrat.variable} ${openSans.variable} ${sora.variable} antialiased`}>
+      <head>
+        <link
+          rel="preload"
+          as="image"
+          href="https://res.cloudinary.com/dakxjcdyp/image/upload/v1756230026/PORTFOLIO_PAGE_10_fzdgem.png"
+        />
+        <link
+          rel="preload"
+          as="image"
+          href="https://res.cloudinary.com/dakxjcdyp/image/upload/v1756230030/PORTFOLIO_PAGE_11_hrn5b0.png"
+        />
+      </head>
       <body className="font-sans">{children}</body>
     </html>
   )

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -1,4 +1,3 @@
-import Head from "next/head"
 import Image, { type ImageProps } from "next/image"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
@@ -37,12 +36,7 @@ interface PreloadImageProps extends Omit<ImageProps, "src"> {
 }
 
 const PreloadImage = ({ src, ...props }: PreloadImageProps) => (
-  <>
-    <Head>
-      <link rel="preload" as="image" href={src} />
-    </Head>
-    <Image src={src} {...props} />
-  </>
+  <Image src={src} {...props} />
 )
 
 const bjornChapterPages = [
@@ -223,7 +217,7 @@ export const portfolioPages = [
           fill
           className="object-cover"
           unoptimized
-          loading="eager"
+          priority
         />
       </div>
     ),
@@ -239,6 +233,7 @@ export const portfolioPages = [
           fill
           className="object-cover"
           unoptimized
+          priority
         />
       </div>
     ),
@@ -248,7 +243,7 @@ export const portfolioPages = [
     id: 8,
     content: (
       <div className="relative w-full h-full">
-        <PreloadImage src={page8} alt="Page 8" fill className="object-cover" unoptimized />
+        <PreloadImage src={page8} alt="Page 8" fill className="object-cover" unoptimized priority />
       </div>
     ),
   },
@@ -257,7 +252,7 @@ export const portfolioPages = [
     id: 9,
     content: (
       <div className="relative w-full h-full">
-        <PreloadImage src={page9} alt="Page 9" fill className="object-cover" unoptimized />
+        <PreloadImage src={page9} alt="Page 9" fill className="object-cover" unoptimized priority />
       </div>
     ),
   },


### PR DESCRIPTION
## Summary
- remove next/head usage in PreloadImage
- preload critical images via priority and layout links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b04ea5be608324b8f823360b4dc0d9