### PR TITLE
Disable flipbook shadow when zoomed in

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -274,10 +274,10 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         width={pageWidth}
         height={pageHeight}
         showCover
-        maxShadowOpacity={0.2}
-        drawShadow
+        maxShadowOpacity={scale <= OPEN_SCALE ? 0.2 : 0}
+        drawShadow={scale <= OPEN_SCALE}
         flippingTime={FLIP_DURATION}
-        showPageCorners
+        showPageCorners={scale <= OPEN_SCALE}
         disableFlipByClick
         swipeDistance={30}
         className="shadow-md flipbook"


### PR DESCRIPTION
## Summary
- disable page corners and shadows when zooming past `OPEN_SCALE`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b052f894708324b2635068db7b40a4