### PR TITLE
Extend portfolio to 30 pages and update pagination references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Portfolio
 
-Ce portfolio comprend désormais un chapitre supplémentaire de dix pages détaillant le processus de conception du projet Björn. La table des matières et la pagination ont été mises à jour pour refléter cette extension.
+Ce portfolio comprend désormais un chapitre supplémentaire de dix pages détaillant le processus de conception du projet Björn, portant le total à 30 pages. La table des matières et la pagination ont été mises à jour pour refléter cette extension.
 
 ## Pagination with Jump
 
@@ -25,7 +25,7 @@ function Example() {
         </PaginationItem>
         <PaginationItem>
           <PaginationJump
-            totalPages={20}
+            totalPages={30}
             onPageChange={(page) => console.log("Go to", page)}
           />
         </PaginationItem>

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -30,6 +30,26 @@ const page16 =
   "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756230040/PORTFOLIO_PAGE_16_nodtmh.png"
 const page17 =
   "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756230034/PORTFOLIO_PAGE_17_tedncj.png"
+const page21 =
+  "https://via.placeholder.com/500x710?text=Page+21"
+const page22 =
+  "https://via.placeholder.com/500x710?text=Page+22"
+const page23 =
+  "https://via.placeholder.com/500x710?text=Page+23"
+const page24 =
+  "https://via.placeholder.com/500x710?text=Page+24"
+const page25 =
+  "https://via.placeholder.com/500x710?text=Page+25"
+const page26 =
+  "https://via.placeholder.com/500x710?text=Page+26"
+const page27 =
+  "https://via.placeholder.com/500x710?text=Page+27"
+const page28 =
+  "https://via.placeholder.com/500x710?text=Page+28"
+const page29 =
+  "https://via.placeholder.com/500x710?text=Page+29"
+const page30 =
+  "https://via.placeholder.com/500x710?text=Page+30"
 
 interface PreloadImageProps extends Omit<ImageProps, "src"> {
   src: string
@@ -259,9 +279,149 @@ export const portfolioPages = [
 
   ...bjornChapterPages,
 
-  // Contact Page (Single - Last page)
+  // Contact Page (Single)
   {
     id: 20,
     content: <div className="w-full h-full bg-white" />,
+  },
+  {
+    id: 21,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page21}
+          alt="Portfolio Page 21"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
+  {
+    id: 22,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page22}
+          alt="Portfolio Page 22"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
+  {
+    id: 23,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page23}
+          alt="Portfolio Page 23"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
+  {
+    id: 24,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page24}
+          alt="Portfolio Page 24"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
+  {
+    id: 25,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page25}
+          alt="Portfolio Page 25"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
+  {
+    id: 26,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page26}
+          alt="Portfolio Page 26"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
+  {
+    id: 27,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page27}
+          alt="Portfolio Page 27"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
+  {
+    id: 28,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page28}
+          alt="Portfolio Page 28"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
+  {
+    id: 29,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page29}
+          alt="Portfolio Page 29"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
+  {
+    id: 30,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page30}
+          alt="Portfolio Page 30"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
   },
 ]


### PR DESCRIPTION
## Summary
- add placeholder image constants for pages 21–30
- append portfolio page entries 21–30 and adjust contact page comment
- document new 30-page total in README and example pagination

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive prompt: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b0777934848324a34e0878d224c3c8