### PR TITLE
Add Cloudinary pages 18-21 to portfolio

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -30,6 +30,14 @@ const page16 =
   "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756230040/PORTFOLIO_PAGE_16_nodtmh.png"
 const page17 =
   "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756230034/PORTFOLIO_PAGE_17_tedncj.png"
+const page18 =
+  "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756396329/PORTFOLIO_PAGE_18_upooms.png"
+const page19 =
+  "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756396488/PORTFOLIO_PAGE_19_jjlnpi.png"
+const page20 =
+  "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756396332/PORTFOLIO_PAGE_20_sxhnkd.png"
+const page21 =
+  "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756396488/PORTFOLIO_PAGE_21_r9mzqz.png"
 
 interface PreloadImageProps extends Omit<ImageProps, "src"> {
   src: string
@@ -165,8 +173,34 @@ const bjornChapterPages = [
       </div>
     ),
   },
-  { id: 18, content: <div className="w-full h-full bg-white" /> },
-  { id: 19, content: <div className="w-full h-full bg-white" /> },
+  {
+    id: 18,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page18}
+          alt="Portfolio Page 18"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
+  {
+    id: 19,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page19}
+          alt="Portfolio Page 19"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
 ]
 
 export const portfolioPages = [
@@ -262,9 +296,32 @@ export const portfolioPages = [
   // Contact Page (Single)
   {
     id: 20,
-    content: <div className="w-full h-full bg-white" />,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page20}
+          alt="Portfolio Page 20"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
   },
-  { id: 21, content: <div className="w-full h-full bg-white" /> },
+  {
+    id: 21,
+    content: (
+      <div className="relative w-full h-full">
+        <PreloadImage
+          src={page21}
+          alt="Portfolio Page 21"
+          fill
+          className="object-cover"
+          unoptimized
+        />
+      </div>
+    ),
+  },
   { id: 22, content: <div className="w-full h-full bg-white" /> },
   { id: 23, content: <div className="w-full h-full bg-white" /> },
   { id: 24, content: <div className="w-full h-full bg-white" /> },


### PR DESCRIPTION
## Summary
- add Cloudinary URLs for portfolio pages 18-21
- render pages 18-21 with PreloadImage components

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm build` *(fails: unable to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b083f467108324957b3d7c0b139dc8