### PR TITLE
Add video overlay player on portfolio page 21

### DIFF
--- a/components/page21-video.tsx
+++ b/components/page21-video.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import Image from "next/image"
+import { useState } from "react"
+
+interface Page21VideoProps {
+  imageSrc: string
+  alt?: string
+}
+
+const Page21Video = ({ imageSrc, alt = "" }: Page21VideoProps) => {
+  const [showVideo, setShowVideo] = useState(false)
+
+  return (
+    <div className="relative w-full h-full">
+      {showVideo ? (
+        <iframe
+          src="https://www.youtube.com/embed/WOCJAxqM7uU"
+          title="Portfolio video"
+          allowFullScreen
+          className="w-full h-full"
+        />
+      ) : (
+        <>
+          <Image
+            src={imageSrc}
+            alt={alt}
+            fill
+            className="object-cover"
+            unoptimized
+          />
+          <div
+            className="absolute top-[100px] left-[100px] w-[150px] h-[100px] cursor-pointer"
+            onClick={() => setShowVideo(true)}
+          />
+        </>
+      )}
+    </div>
+  )
+}
+
+export default Page21Video

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import fs from "fs"
 import path from "path"
+import Page21Video from "./page21-video"
 
 const readDataUri = (file: string) =>
   fs.readFileSync(path.join(process.cwd(), "public/images", file), "utf8")
@@ -310,17 +311,7 @@ export const portfolioPages = [
   },
   {
     id: 21,
-    content: (
-      <div className="relative w-full h-full">
-        <PreloadImage
-          src={page21}
-          alt="Portfolio Page 21"
-          fill
-          className="object-cover"
-          unoptimized
-        />
-      </div>
-    ),
+    content: <Page21Video imageSrc={page21} alt="Portfolio Page 21" />,
   },
   { id: 22, content: <div className="w-full h-full bg-white" /> },
   { id: 23, content: <div className="w-full h-full bg-white" /> },


### PR DESCRIPTION
## Summary
- add client-side component to toggle a YouTube embed over page 21 image
- wire portfolio pages to render new video overlay component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: Failed to fetch `Montserrat` from Google Fonts.)*


------
https://chatgpt.com/codex/tasks/task_e_68b090fbb29c832488ad34095ece87d4