### PR TITLE
Add video modal overlay for portfolio page 21

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -1,7 +1,6 @@
 import Image, { type ImageProps } from "next/image"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
-import { Play } from "lucide-react"
 import { VideoModal } from "@/components/video-modal"
 import fs from "fs"
 import path from "path"
@@ -321,18 +320,17 @@ export const portfolioPages = [
           className="object-cover"
           unoptimized
         />
-        <VideoModal
-          trigger={
-            <button
-              className="absolute top-[6.6%] left-[9.4%] w-[37.5%] h-[33.3%] flex items-center justify-center cursor-pointer z-10"
-            >
-              <Play className="w-16 h-16 text-white" />
-            </button>
-          }
-        />
-      </div>
-    ),
-  },
+          <VideoModal
+            trigger={
+              <button
+                aria-label="Play video"
+                className="absolute left-[11%] bottom-[6.7%] w-[39.9%] h-[42.5%] cursor-pointer bg-transparent"
+              />
+            }
+          />
+        </div>
+      ),
+    },
   { id: 22, content: <div className="w-full h-full bg-white" /> },
   { id: 23, content: <div className="w-full h-full bg-white" /> },
   { id: 24, content: <div className="w-full h-full bg-white" /> },

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -1,6 +1,8 @@
 import Image, { type ImageProps } from "next/image"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import { Play } from "lucide-react"
+import { VideoModal } from "@/components/video-modal"
 import fs from "fs"
 import path from "path"
 
@@ -318,6 +320,15 @@ export const portfolioPages = [
           fill
           className="object-cover"
           unoptimized
+        />
+        <VideoModal
+          trigger={
+            <button
+              className="absolute top-[6.6%] left-[9.4%] w-[37.5%] h-[33.3%] flex items-center justify-center cursor-pointer z-10"
+            >
+              <Play className="w-16 h-16 text-white" />
+            </button>
+          }
         />
       </div>
     ),

--- a/components/video-modal.tsx
+++ b/components/video-modal.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
+
+interface VideoModalProps {
+  trigger: ReactNode
+}
+
+export function VideoModal({ trigger }: VideoModalProps) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="max-w-4xl w-full p-0" showCloseButton>
+        <div className="aspect-video w-full">
+          <iframe
+            src="https://www.youtube.com/embed/WOCJAxqM7uU?autoplay=1"
+            title="YouTube video player"
+            allow="autoplay; encrypted-media"
+            allowFullScreen
+            className="w-full h-full"
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default VideoModal


### PR DESCRIPTION
## Summary
- add `VideoModal` component using shadcn dialog to show a YouTube embed
- overlay a responsive play button on portfolio page 21 and open modal on click

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b099827854832489f05718e9a961b9