### PR TITLE
Increase video modal width

### DIFF
--- a/components/video-modal.tsx
+++ b/components/video-modal.tsx
@@ -11,7 +11,7 @@ export function VideoModal({ trigger }: VideoModalProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent className="max-w-4xl w-full p-0" showCloseButton>
+      <DialogContent className="max-w-[90vw] w-full p-0" showCloseButton>
         <div className="aspect-video w-full">
           <iframe
             src="https://www.youtube.com/embed/WOCJAxqM7uU?autoplay=1"


### PR DESCRIPTION
## Summary
- widen VideoModal dialog max width to 90vw so videos display larger

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b9b582348324b54e5c31f49f3c38