### PR TITLE
feat: expand video modal width

### DIFF
--- a/components/video-modal.tsx
+++ b/components/video-modal.tsx
@@ -11,7 +11,7 @@ export function VideoModal({ trigger }: VideoModalProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent className="max-w-4xl w-full p-0" showCloseButton>
+      <DialogContent className="max-w-6xl w-full p-0" showCloseButton>
         <div className="aspect-video w-full">
           <iframe
             src="https://www.youtube.com/embed/WOCJAxqM7uU?autoplay=1"


### PR DESCRIPTION
## Summary
- increase video modal width to 6xl
- confirm iframe fills the modal container

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c20f55848324bb8760a9b43f999f