### PR TITLE
Use PlayIcon with thin stroke for video trigger

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -327,7 +327,7 @@ export const portfolioPages = [
               className="absolute left-[11%] bottom-[6.7%] w-[39.9%] h-[42.5%] flex items-center justify-center bg-transparent"
               aria-label="Play video"
             >
-              <PlayIcon className="w-12 h-12 text-white" />
+              <PlayIcon className="w-12 h-12 text-white stroke-[1.5]" />
             </button>
           }
         />


### PR DESCRIPTION
## Summary
- switch video trigger to PlayIcon and remove rounded styling
- refine PlayIcon stroke for thin outline

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: sh: 1: next: not found)

------
https://chatgpt.com/codex/tasks/task_e_68b0c274e4c48324ba600275b2d26133