### PR TITLE
Add book-clickable class to page 21 video trigger

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -324,7 +324,7 @@ export const portfolioPages = [
         <VideoModal
           trigger={
             <button
-              className="absolute left-[11%] bottom-[6.7%] w-[39.9%] h-[42.5%] flex items-center justify-center bg-transparent hover:bg-black/20 transition-colors"
+              className="book-clickable absolute left-[11%] bottom-[6.7%] w-[39.9%] h-[42.5%] flex items-center justify-center bg-transparent hover:bg-black/20 transition-colors"
               aria-label="Play video"
             >
               <PlayIcon className="w-12 h-12 text-white" />


### PR DESCRIPTION
## Summary
- highlight page 21 video trigger with `book-clickable`

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run lint` *(fails: asked for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c672fd8083249530fbf86b0595e0