### PR TITLE
Replace play icon with PlayCircle

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -2,7 +2,7 @@ import Image, { type ImageProps } from "next/image"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { VideoModal } from "@/components/video-modal"
-import { PlayIcon } from "lucide-react"
+import { PlayCircle } from "lucide-react"
 import fs from "fs"
 import path from "path"
 
@@ -327,7 +327,11 @@ export const portfolioPages = [
               className="absolute left-[11%] bottom-[6.7%] w-[39.9%] h-[42.5%] flex items-center justify-center bg-transparent hover:bg-black/20 transition-colors"
               aria-label="Play video"
             >
-              <PlayIcon className="w-12 h-12 text-white" />
+              <PlayCircle
+                className="w-12 h-12 text-white"
+                stroke="white"
+                fill="white"
+              />
             </button>
           }
         />

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -2,7 +2,6 @@ import Image, { type ImageProps } from "next/image"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
 import { VideoModal } from "@/components/video-modal"
-import { PlayCircle } from "lucide-react"
 import fs from "fs"
 import path from "path"
 
@@ -327,11 +326,21 @@ export const portfolioPages = [
               className="absolute left-[11%] bottom-[6.7%] w-[39.9%] h-[42.5%] flex items-center justify-center bg-transparent hover:bg-black/20 transition-colors"
               aria-label="Play video"
             >
-              <PlayCircle
+              <svg
+                viewBox="0 0 24 24"
                 className="w-12 h-12 text-white"
-                stroke="white"
-                fill="white"
-              />
+                aria-hidden="true"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="11"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                />
+                <polygon points="10,8 16,12 10,16" fill="currentColor" />
+              </svg>
             </button>
           }
         />


### PR DESCRIPTION
## Summary
- swap PlayIcon for PlayCircle on portfolio page 21
- ensure play icon has white stroke and fill

## Testing
- `pnpm lint` *(fails: project prompts for ESLint setup and cannot run in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d3a1820c83249eed34f81d02e3c6