### PR TITLE
Add loading screen and preload portfolio images

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,36 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import { MagazineViewer } from "@/components/magazine-viewer"
-import { portfolioPages } from "@/components/portfolio-pages"
+import { portfolioPages, portfolioImageUrls } from "@/components/portfolio-pages"
 import { ErrorBoundary } from "@/components/error-boundary"
+import { LoadingScreen } from "@/components/loading-screen"
 
 export default function Home() {
+  const [isLoaded, setIsLoaded] = useState(false)
+
+  useEffect(() => {
+    const preload = async () => {
+      await Promise.all(
+        portfolioImageUrls.map(
+          (src) =>
+            new Promise<void>((resolve) => {
+              const img = new Image()
+              img.src = src
+              img.onload = () => resolve()
+              img.onerror = () => resolve()
+            })
+        )
+      )
+      setIsLoaded(true)
+    }
+    preload()
+  }, [])
+
   return (
     <main className="min-h-screen">
       <ErrorBoundary>
-        <MagazineViewer pages={portfolioPages} />
+        {isLoaded ? <MagazineViewer pages={portfolioPages} /> : <LoadingScreen />}
       </ErrorBoundary>
     </main>
   )

--- a/components/loading-screen.tsx
+++ b/components/loading-screen.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+export function LoadingScreen() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-black text-white">
+      <svg
+        className="h-12 w-12 animate-spin"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+        />
+      </svg>
+    </div>
+  )
+}

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -357,3 +357,23 @@ export const portfolioPages = [
   { id: 29, content: <div className="w-full h-full bg-white" /> },
   { id: 30, content: <div className="w-full h-full bg-white" /> },
 ]
+
+export const portfolioImageUrls = [
+  portfolioCover,
+  page6,
+  page7,
+  page8,
+  page9,
+  page10,
+  page11,
+  page12,
+  page13,
+  page14,
+  page15,
+  page16,
+  page17,
+  page18,
+  page19,
+  page20,
+  page21,
+]


### PR DESCRIPTION
## Summary
- add animated loading screen component
- preload magazine images before rendering
- expose portfolio image URLs for preloading

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b2014994e88324a71ce822b7892d16