### PR TITLE
feat: add quality prop to PreloadImage

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -42,10 +42,11 @@ const page21 =
 
 interface PreloadImageProps extends Omit<ImageProps, "src"> {
   src: string
+  quality?: number
 }
 
-const PreloadImage = ({ src, ...props }: PreloadImageProps) => (
-  <Image src={src} {...props} />
+const PreloadImage = ({ src, quality = 100, ...props }: PreloadImageProps) => (
+  <Image src={src} quality={quality} {...props} />
 )
 
 const bjornChapterPages = [


### PR DESCRIPTION
## Summary
- allow PreloadImage to accept quality option with default 100 for higher fidelity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b2414500748324a52c699018fd4d30