### PR TITLE
test: add visual regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+playwright-report/
+playwright-report
+report/
+test-results/
+**/test-results/
+**/playwright-report/
+
+.next/

--- a/app/visual/magazine/page.tsx
+++ b/app/visual/magazine/page.tsx
@@ -1,0 +1,14 @@
+import { MagazineViewer } from "@/components/magazine-viewer";
+
+const samplePages = [
+  { id: 1, content: <div className="w-full h-full bg-white" /> },
+  { id: 2, content: <div className="w-full h-full bg-gray-200" /> },
+];
+
+export default function MagazineVisualPage() {
+  return (
+    <main className="min-h-screen">
+      <MagazineViewer pages={samplePages} />
+    </main>
+  );
+}

--- a/app/visual/portfolio/page.tsx
+++ b/app/visual/portfolio/page.tsx
@@ -1,0 +1,10 @@
+import { MagazineViewer } from "@/components/magazine-viewer";
+import { portfolioPages } from "@/components/portfolio-pages";
+
+export default function PortfolioVisualPage() {
+  return (
+    <main className="min-h-screen">
+      <MagazineViewer pages={portfolioPages} />
+    </main>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "zod": "3.25.67"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "@tailwindcss/postcss": "^4.1.9",
         "@types/node": "^22",
         "@types/react": "^19",
@@ -712,6 +713,22 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -2884,6 +2901,21 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/geist": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/geist/-/geist-1.4.2.tgz",
@@ -3411,6 +3443,38 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test:visual": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -62,6 +63,7 @@
     "zod": "3.25.67"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@tailwindcss/postcss": "^4.1.9",
     "@types/node": "^22",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/visual',
+  use: {
+    baseURL: 'http://localhost:3000',
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/tests/visual/critical-components.spec.ts
+++ b/tests/visual/critical-components.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+const viewports = [375, 768, 1080, 1920];
+
+test.describe('Portfolio pages', () => {
+  for (const width of viewports) {
+    test(`should match at width ${width}`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 800 });
+      await page.goto('/visual/portfolio');
+      await expect(page).toHaveScreenshot(`portfolio-${width}.png`);
+    });
+  }
+});
+
+test.describe('Magazine viewer', () => {
+  for (const width of viewports) {
+    test(`should match at width ${width}`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 800 });
+      await page.goto('/visual/magazine');
+      await expect(page).toHaveScreenshot(`magazine-${width}.png`);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- set up Playwright config and script for visual tests
- add test pages for `MagazineViewer` and portfolio content
- introduce screenshot tests across multiple viewport widths

## Testing
- `npm run test:visual` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*


------
https://chatgpt.com/codex/tasks/task_e_68b2444f9d78832482f23fb40a56ebe4