### PR TITLE
feat: optimize Cloudinary image loading

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,12 +39,12 @@ export default function RootLayout({
         <link
           rel="preload"
           as="image"
-          href="https://res.cloudinary.com/dakxjcdyp/image/upload/v1756230026/PORTFOLIO_PAGE_10_fzdgem.png"
+          href="https://res.cloudinary.com/dakxjcdyp/image/upload/f_auto,q_auto/v1756230026/PORTFOLIO_PAGE_10_fzdgem.png"
         />
         <link
           rel="preload"
           as="image"
-          href="https://res.cloudinary.com/dakxjcdyp/image/upload/v1756230030/PORTFOLIO_PAGE_11_hrn5b0.png"
+          href="https://res.cloudinary.com/dakxjcdyp/image/upload/f_auto,q_auto/v1756230030/PORTFOLIO_PAGE_11_hrn5b0.png"
         />
       </head>
       <body className="font-sans">{children}</body>

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -44,9 +44,32 @@ interface PreloadImageProps extends Omit<ImageProps, "src"> {
   src: string
 }
 
-const PreloadImage = ({ src, ...props }: PreloadImageProps) => (
-  <Image src={src} {...props} quality={90} sizes="100vw" />
-)
+const PreloadImage = ({ src, priority, ...props }: PreloadImageProps) => {
+  const isCloudinary = src.includes("res.cloudinary.com")
+  const hasParams = src.includes("/upload/f_auto,q_auto/")
+  const transformedSrc = isCloudinary && !hasParams
+    ? src.replace("/upload/", "/upload/f_auto,q_auto/")
+    : src
+  const blurDataURL = isCloudinary
+    ? transformedSrc.replace(
+        "/upload/f_auto,q_auto/",
+        "/upload/f_auto,q_auto,w_10/",
+      )
+    : undefined
+
+  return (
+    <Image
+      src={transformedSrc}
+      {...props}
+      quality={90}
+      sizes="100vw"
+      loading={priority ? "eager" : "lazy"}
+      placeholder={blurDataURL ? "blur" : undefined}
+      blurDataURL={blurDataURL}
+      priority={priority}
+    />
+  )
+}
 
 const bjornChapterPages = [
   {


### PR DESCRIPTION
## Summary
- add automatic format and quality parameters for Cloudinary images
- enable lazy loading with blur placeholders
- preload Cloudinary images using auto format/quality

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts to configure ESLint)
- `npm run build` (fails: cannot fetch Google Fonts)

------
https://chatgpt.com/codex/tasks/task_e_68b2445f7280832491ed90c5f7c7c01b