### PR TITLE
feat: responsive magazine viewer scaling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -243,3 +243,16 @@
 .book-clickable:hover:active {
   filter: brightness(1.15);
 }
+
+.book-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.book {
+  max-height: 90vh;
+  max-width: 80vw;
+  object-fit: contain;
+}


### PR DESCRIPTION
## Summary
- dynamically size magazine pages based on viewport and update on resize
- center book in a full-height container and limit book dimensions via CSS

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c18ef6c88324a2313557fd18b9ff