### PR TITLE
Improve Cloudinary image responsiveness

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -61,9 +61,12 @@ const CloudinaryImage = ({ src, alt, className, ...props }: CloudinaryImageProps
     <img
       src={src1600}
       srcSet={srcset}
-      sizes="(max-width: 768px) 100vw, (max-width: 1920px) 50vw, 1200px"
+      sizes="(max-width: 768px) 100vw, 50vw"
       alt={alt}
-      className={cn("absolute inset-0 h-full w-full object-cover", className)}
+      className={cn(
+        "absolute inset-0 w-full max-w-full h-auto object-cover",
+        className,
+      )}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- ensure Cloudinary images scale responsively with `max-w-full` and `h-auto`
- update `sizes` attribute to match container width

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompting for ESLint config)
- `npm run build` (fails: Failed to fetch fonts, build aborted)


------
https://chatgpt.com/codex/tasks/task_e_68b2cc6e1b808324b887718940e74dab