### PR TITLE
feat: add viewport scaling hook

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,14 @@
 import { MagazineViewer } from "@/components/magazine-viewer"
 import { portfolioPages } from "@/components/portfolio-pages"
 import { ErrorBoundary } from "@/components/error-boundary"
+import { useViewportScale } from "@/hooks/use-viewport-scale"
 
 export default function Home() {
+  const viewportScale = useViewportScale(1000, 710)
   return (
     <main className="min-h-screen">
       <ErrorBoundary>
-        <MagazineViewer pages={portfolioPages} />
+        <MagazineViewer pages={portfolioPages} viewportScale={viewportScale} />
       </ErrorBoundary>
     </main>
   )

--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -24,9 +24,10 @@ interface Page {
 
 interface MagazineViewerProps {
   pages: Page[]
+  viewportScale: number
 }
 
-export function MagazineViewer({ pages }: MagazineViewerProps) {
+export function MagazineViewer({ pages, viewportScale }: MagazineViewerProps) {
   const bookRef = useRef<FlipBook | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
   const [currentPage, setCurrentPage] = useState(0)
@@ -284,7 +285,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         ref={bookRef}
         onFlip={handleFlip}
         style={{
-          transform: `translate(${offsetX + translate.x}px, ${translate.y}px) scale(${scale})`,
+          transform: `translate(${offsetX + translate.x}px, ${translate.y}px) scale(${scale * viewportScale})`,
           transition: isDragging ? "none" : "transform 0.3s ease",
           transformOrigin: "0 0",
           ["--flip-duration" as any]: `${FLIP_DURATION}ms`,
@@ -333,6 +334,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
           totalPages={totalPages}
           currentPage={currentPage + 1}
           goToPage={goToPage}
+          scale={viewportScale}
         />
       </div>
 

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -15,13 +15,16 @@ interface PaginationProps extends React.ComponentProps<"div"> {
   totalPages: number
   currentPage: number
   goToPage: (page: number) => void
+  scale?: number
 }
 
 function Pagination({
   totalPages,
   currentPage,
   goToPage,
+  scale = 1,
   className,
+  style,
   ...props
 }: PaginationProps) {
   const pages = Array.from({ length: totalPages }, (_, i) => i + 1)
@@ -30,6 +33,7 @@ function Pagination({
     <div
       data-slot="pagination"
       className={cn("mx-auto flex w-full justify-center", className)}
+      style={{ transform: `scale(${scale})`, transformOrigin: "bottom left", ...style }}
       {...props}
     >
       <Select

--- a/hooks/use-viewport-scale.ts
+++ b/hooks/use-viewport-scale.ts
@@ -1,0 +1,20 @@
+import * as React from "react"
+
+export function useViewportScale(baseWidth: number, baseHeight: number) {
+  const [scale, setScale] = React.useState(1)
+
+  React.useEffect(() => {
+    const updateScale = () => {
+      const { innerWidth, innerHeight } = window
+      const newScale = Math.min(innerWidth / baseWidth, innerHeight / baseHeight)
+      setScale(newScale)
+      document.documentElement.style.setProperty("--viewport-scale", newScale.toString())
+    }
+    updateScale()
+    window.addEventListener("resize", updateScale)
+    return () => window.removeEventListener("resize", updateScale)
+  }, [baseWidth, baseHeight])
+
+  return scale
+}
+


### PR DESCRIPTION
## Summary
- add `useViewportScale` hook to compute scaling factor from viewport
- pass viewport scale to `MagazineViewer` and `Pagination`
- scale magazine display and pagination using CSS transforms

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint config)


------
https://chatgpt.com/codex/tasks/task_e_68b2cc75c3648324989fba7d0c909995