### PR TITLE
feat: dynamically size magazine viewer

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -39,28 +39,34 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
 
   const totalPages = pages.length
 
+  const getBookSize = () => {
+    const innerHeight = window.innerHeight
+    const innerWidth = window.innerWidth
+
+    let height = Math.min(
+      Math.max(0.85 * innerHeight, 0.8 * innerHeight),
+      0.9 * innerHeight,
+    )
+    let width = height * PAGE_RATIO
+
+    const maxPageWidth = (innerWidth * 0.9) / 2
+    if (width > maxPageWidth) {
+      width = maxPageWidth
+      height = width / PAGE_RATIO
+    }
+
+    return { width, height }
+  }
+
   const [bookSize, setBookSize] = useState(() => {
     if (typeof window !== "undefined") {
-      const innerHeight = window.innerHeight
-      const height = Math.min(
-        Math.max(0.85 * innerHeight, 0.8 * innerHeight),
-        0.9 * innerHeight,
-      )
-      return { height, width: height * PAGE_RATIO }
+      return getBookSize()
     }
     return { width: 500, height: 710 }
   })
 
   useEffect(() => {
-    const updateSize = () => {
-      const innerHeight = window.innerHeight
-      const height = Math.min(
-        Math.max(0.85 * innerHeight, 0.8 * innerHeight),
-        0.9 * innerHeight,
-      )
-      const width = height * PAGE_RATIO
-      setBookSize({ width, height })
-    }
+    const updateSize = () => setBookSize(getBookSize())
     updateSize()
     window.addEventListener("resize", updateSize)
     return () => window.removeEventListener("resize", updateSize)
@@ -69,12 +75,15 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
   const { width: bookWidth, height: bookHeight } = bookSize
   const scaledPageWidth = bookWidth * scale
   const scaledPageHeight = bookHeight * scale
-  const offsetX =
-    currentPage === 0
-      ? -bookWidth / 2
-      : currentPage === totalPages - 1
-      ? bookWidth / 2
-      : 0
+  const singlePage =
+    typeof window !== "undefined" && bookWidth * 2 > window.innerWidth
+  const offsetX = singlePage
+    ? 0
+    : currentPage === 0
+    ? -bookWidth / 2
+    : currentPage === totalPages - 1
+    ? bookWidth / 2
+    : 0
 
   const handleNextPage = () => {
     bookRef.current?.pageFlip()?.flipNext()
@@ -103,12 +112,13 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         .scale(scale)
       const bookPoint = point.matrixTransform(currentMatrix.inverse())
 
-      const offsetXNew =
-        currentPage === 0
-          ? -bookWidth / 2
-          : currentPage === totalPages - 1
-          ? bookWidth / 2
-          : 0
+      const offsetXNew = singlePage
+        ? 0
+        : currentPage === 0
+        ? -bookWidth / 2
+        : currentPage === totalPages - 1
+        ? bookWidth / 2
+        : 0
 
       const newTranslateX = point.x - offsetXNew - bookPoint.x * newScale
       const newTranslateY = point.y - bookPoint.y * newScale
@@ -116,7 +126,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
       setTranslate({ x: newTranslateX, y: newTranslateY })
       setScale(newScale)
     },
-    [currentPage, totalPages, offsetX, scale, translate, bookWidth]
+    [currentPage, totalPages, offsetX, scale, translate, bookWidth, singlePage]
   )
 
   const zoom = (delta: number) => {


### PR DESCRIPTION
## Summary
- compute magazine dimensions from `window.innerHeight` with clamp and aspect ratio
- use dynamic `bookWidth`/`bookHeight` throughout and pass to `<HTMLFlipBook>`
- update zoom logic to rely on new base dimensions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `node -e "const clamp=(min,v,max)=>Math.min(Math.max(v,min),max);const ratio=500/710;[600,900,1200].forEach(h=>{const bh=clamp(0.8*h,0.85*h,0.9*h);const bw=bh*ratio;console.log(h,'->',bh.toFixed(2),bw.toFixed(2));});"`

------
https://chatgpt.com/codex/tasks/task_e_68b32d6243c483248707ff0e9d9e70e5