### PR TITLE
Ensure magazine viewer has vertical margins

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -15,6 +15,7 @@ const CLOSED_SCALE = 1
 const OPEN_SCALE = 1
 const INITIAL_POS = { x: 0, y: 0 }
 const FLIP_DURATION = 700
+const V_MARGIN = 40
 
 interface Page {
   id: number
@@ -50,10 +51,11 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
   useEffect(() => {
     const updateSize = () => {
       const { innerWidth, innerHeight } = window
+      const availableHeight = innerHeight - V_MARGIN * 2
       let newWidth = innerWidth
       let newHeight = newWidth / PAGE_RATIO
-      if (newHeight > innerHeight) {
-        newHeight = innerHeight
+      if (newHeight > availableHeight) {
+        newHeight = availableHeight
         newWidth = newHeight * PAGE_RATIO
       }
       setPageSize({ width: newWidth, height: newHeight })
@@ -284,7 +286,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
   return (
     <div
       ref={containerRef}
-      className="relative w-full h-screen overflow-hidden flex items-center justify-center p-4"
+      className="relative w-full h-screen overflow-hidden flex items-center justify-center px-4 py-10"
       style={{ backgroundColor: "#0E0E0E" }}
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}


### PR DESCRIPTION
## Summary
- add `V_MARGIN` constant to control vertical spacing
- limit page sizing to available viewport height
- include vertical padding in magazine viewer container

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(incomplete: prompts for ESLint configuration)*
- `npm run build` *(fails: cannot fetch font files)*

------
https://chatgpt.com/codex/tasks/task_e_68b369444c248324a3edfe056a9b2680