### PR TITLE
refactor: adjust magazine viewer container height

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -284,7 +284,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
   return (
     <div
       ref={containerRef}
-      className="relative w-full h-screen overflow-hidden flex items-center justify-center p-4"
+      className="relative w-full min-h-screen overflow-hidden flex items-center justify-center px-4 py-10"
       style={{ backgroundColor: "#0E0E0E" }}
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}


### PR DESCRIPTION
## Summary
- use `min-h-screen` for magazine viewer container height
- switch padding to `px-4 py-10` for clearer spacing

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b3695d262083248ac8e4ac6b7b56ff