### PR TITLE
feat: improve Cloudinary image responsiveness

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -41,8 +41,11 @@ const page20 =
 const page21 =
   "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756396488/PORTFOLIO_PAGE_21_r9mzqz.png"
 
-const buildSrc = (baseUrl: string, width: number) =>
-  baseUrl.replace("/upload/", `/upload/w_${width}/`)
+const buildSrc = (baseUrl: string, width: number, dpr = 1) =>
+  baseUrl.replace(
+    "/upload/",
+    `/upload/f_auto,q_auto,w_${width},dpr_${dpr}/`
+  )
 
 interface CloudinaryImageProps
   extends React.ImgHTMLAttributes<HTMLImageElement> {
@@ -55,6 +58,8 @@ const CloudinaryImage = ({ src, alt, className, ...props }: CloudinaryImageProps
     `${buildSrc(src, 800)} 800w`,
     `${src1600} 1600w`,
     `${buildSrc(src, 2400)} 2400w`,
+    `${buildSrc(src, 1600, 2)} 3200w`,
+    `${buildSrc(src, 2400, 2)} 4800w`,
   ].join(", ")
 
   return (


### PR DESCRIPTION
## Summary
- add f_auto, q_auto, and dpr params to Cloudinary buildSrc
- extend CloudinaryImage srcset with larger widths and high-density variants

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b387b76c688324927765926fac874c