### PR TITLE
refactor: replace page 17 image with text component

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -30,8 +30,6 @@ const page15 =
   "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756230040/PORTFOLIO_PAGE_15_tairwx.png"
 const page16 =
   "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756230040/PORTFOLIO_PAGE_16_nodtmh.png"
-const page17 =
-  "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756230034/PORTFOLIO_PAGE_17_tedncj.png"
 const page18 =
   "https://res.cloudinary.com/dakxjcdyp/image/upload/v1756396329/PORTFOLIO_PAGE_18_upooms.png"
 const page19 =
@@ -75,6 +73,40 @@ interface PreloadImageProps extends Omit<ImageProps, "src"> {
 
 const PreloadImage = ({ src, ...props }: PreloadImageProps) => (
   <Image src={src} {...props} quality={90} sizes="100vw" />
+)
+
+const Page17 = () => (
+  <div className="p-12 bg-white w-full h-full font-sans">
+    <h1 className="text-4xl font-bold mb-6 font-serif">Site web MBAT</h1>
+    <p className="text-lg leading-relaxed">
+      Refonte du site du Marathon des Arts et du Tennis mettant l'accent sur
+      une lecture claire et une typographie soignée.
+    </p>
+    <svg
+      className="w-16 h-16 mt-8 text-primary"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M8 12l2 2 4-4" />
+    </svg>
+    <Link
+      href="https://www.figma.com/proto/NITAGZXbWhIXvS86y4oytS/Site-Web-MBAT?page-id=0%3A1&node-id=176-9725&viewport=777%2C-291%2C0.31&t=QTx62eY5jD6B6o68-8&scaling=scale-down-width&content-scaling=fixed&hide-ui=1"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <Button
+        variant="outline"
+        highlight
+        className="mt-8 border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
+      >
+        visiter le site
+      </Button>
+    </Link>
+  </div>
 )
 
 const bjornChapterPages = [
@@ -136,24 +168,7 @@ const bjornChapterPages = [
   },
   {
     id: 17,
-    content: (
-      <div className="relative w-full h-full">
-        <CloudinaryImage src={page17} alt="Portfolio Page 17" />
-        <Link
-          href="https://www.figma.com/proto/NITAGZXbWhIXvS86y4oytS/Site-Web-MBAT?page-id=0%3A1&node-id=176-9725&viewport=777%2C-291%2C0.31&t=QTx62eY5jD6B6o68-8&scaling=scale-down-width&content-scaling=fixed&hide-ui=1"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Button
-            variant="outline"
-            highlight
-            className="absolute bottom-30 left-[51%] z-10 -translate-x-1/2 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
-          >
-            visiter le site
-          </Button>
-        </Link>
-      </div>
-    ),
+    content: <Page17 />,
   },
   {
     id: 18,


### PR DESCRIPTION
## Summary
- replace page 17 Cloudinary PNG with structured React component
- render page 17 text with web fonts and inline SVG to keep vector quality

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b435f8060c832496b06d33da18fc96