### PR TITLE
Adjust Bjorn site link button position

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -147,7 +147,7 @@ const bjornChapterPages = [
           <Button
             variant="outline"
             highlight
-            className="absolute bottom-30 left-[51%] z-10 -translate-x-1/2 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
+            className="absolute left-[37%] bottom-[17%] z-10 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
           >
             visiter le site
           </Button>


### PR DESCRIPTION
## Summary
- tweak Bjorn site link button placement to use 37% left offset and 17% bottom offset

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d1eca2bc8324ba6c1d304b3f0903