### PR TITLE
Add viewport meta tag to root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,6 +36,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${montserrat.variable} ${openSans.variable} ${sora.variable} antialiased`}>
       <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link
           rel="preload"
           as="image"


### PR DESCRIPTION
## Summary
- ensure responsive scaling by including a viewport meta tag in the document head

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e194d04c8324b90b2b3caebcd99d