### PR TITLE
feat: add viewport hook

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -2,6 +2,7 @@
 
 import type React from "react"
 import { useState, useRef, useEffect, useCallback } from "react"
+import { useViewport } from "@/hooks/useViewport"
 import { Plus, Minus, ChevronLeft, ChevronRight } from "lucide-react"
 import dynamic from "next/dynamic"
 import { Button } from "@/components/ui/button"
@@ -39,6 +40,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
   const totalPages = pages.length
   const PAGE_RATIO = 500 / 710
   const [{ width, height }, setPageSize] = useState({ width: 500, height: 710 })
+  const { width: viewportWidth, height: viewportHeight } = useViewport()
   const pageWidth = width * scale
   const pageHeight = height * scale
   const offsetX =
@@ -49,10 +51,10 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
       : 0
 
   useEffect(() => {
+    if (!viewportWidth || !viewportHeight) return
     const updateSize = () => {
-      const { innerWidth, innerHeight } = window
-      const availableHeight = innerHeight - V_MARGIN * 2
-      let newWidth = innerWidth
+      const availableHeight = viewportHeight - V_MARGIN * 2
+      let newWidth = viewportWidth
       let newHeight = newWidth / PAGE_RATIO
       if (newHeight > availableHeight) {
         newHeight = availableHeight
@@ -66,13 +68,11 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
     const container = containerRef.current
     const resizeObserver = new ResizeObserver(updateSize)
     if (container) resizeObserver.observe(container)
-    window.addEventListener("resize", updateSize)
 
     return () => {
       resizeObserver.disconnect()
-      window.removeEventListener("resize", updateSize)
     }
-  }, [])
+  }, [viewportWidth, viewportHeight])
 
   const handleNextPage = () => {
     bookRef.current?.pageFlip()?.flipNext()

--- a/components/responsive-book.tsx
+++ b/components/responsive-book.tsx
@@ -1,22 +1,10 @@
 "use client"
 
-import { useEffect, useState } from "react"
 import dynamic from "next/dynamic"
+import { useViewport } from "@/hooks/useViewport"
 
 function ResponsiveBook() {
-  const [screenHeight, setScreenHeight] = useState(0)
-  const [screenWidth, setScreenWidth] = useState(0)
-
-  useEffect(() => {
-    const updateSize = () => {
-      setScreenHeight(window.innerHeight)
-      setScreenWidth(window.innerWidth)
-    }
-
-    updateSize()
-    window.addEventListener("resize", updateSize)
-    return () => window.removeEventListener("resize", updateSize)
-  }, [])
+  const { width: screenWidth, height: screenHeight } = useViewport()
 
   return (
     <div

--- a/hooks/useViewport.ts
+++ b/hooks/useViewport.ts
@@ -1,0 +1,23 @@
+import * as React from "react"
+
+interface Viewport {
+  width: number
+  height: number
+}
+
+export function useViewport() {
+  const [viewport, setViewport] = React.useState<Viewport>({ width: 0, height: 0 })
+
+  React.useEffect(() => {
+    const update = () => {
+      setViewport({ width: window.innerWidth, height: window.innerHeight })
+    }
+
+    update()
+    window.addEventListener("resize", update)
+    return () => window.removeEventListener("resize", update)
+  }, [])
+
+  return viewport
+}
+


### PR DESCRIPTION
## Summary
- add `useViewport` hook to expose window dimensions
- refactor magazine viewer and responsive book to rely on the hook instead of manual resize listeners

## Testing
- `npm run lint` *(fails: requires ESLint configuration setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e1959c448324b70b04b78be4b16a