### PR TITLE
Enable mobile-friendly magazine viewer

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -7,6 +7,7 @@ import dynamic from "next/dynamic"
 import { Button } from "@/components/ui/button"
 import { Pagination } from "@/components/ui/pagination"
 import { FullScreenButton } from "@/components/fullscreen-button"
+import { useIsMobile } from "@/components/ui/use-mobile"
 import type { default as FlipBook } from "react-pageflip"
 
 const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false })
@@ -30,6 +31,7 @@ interface MagazineViewerProps {
 export function MagazineViewer({ pages }: MagazineViewerProps) {
   const bookRef = useRef<FlipBook | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  const isMobile = useIsMobile()
   const [currentPage, setCurrentPage] = useState(0)
   const [scale, setScale] = useState(CLOSED_SCALE)
   const [translate, setTranslate] = useState(INITIAL_POS)
@@ -53,6 +55,9 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
       const { innerWidth, innerHeight } = window
       const availableHeight = innerHeight - V_MARGIN * 2
       let newWidth = innerWidth
+      if (isMobile) {
+        newWidth = innerWidth / 2
+      }
       let newHeight = newWidth / PAGE_RATIO
       if (newHeight > availableHeight) {
         newHeight = availableHeight
@@ -72,7 +77,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
       resizeObserver.disconnect()
       window.removeEventListener("resize", updateSize)
     }
-  }, [])
+  }, [isMobile])
 
   const handleNextPage = () => {
     bookRef.current?.pageFlip()?.flipNext()
@@ -306,6 +311,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         showPageCorners
         disableFlipByClick
         swipeDistance={30}
+        usePortrait={isMobile}
         className="shadow-md flipbook"
         ref={bookRef}
         onFlip={handleFlip}

--- a/manual-tests/magazine-viewer-mobile.md
+++ b/manual-tests/magazine-viewer-mobile.md
@@ -1,0 +1,10 @@
+# Magazine Viewer Mobile Manual Test
+
+1. Run the development server:
+   ```bash
+   npm run dev
+   ```
+2. Open `http://localhost:3000` in a desktop browser and verify that two pages are visible side by side.
+3. Open the same URL on a mobile device or using the browser's mobile device emulator.
+4. Confirm that only a single page is visible and that it fits within the viewport.
+5. Flip pages and verify that navigation and zoom controls work as expected.


### PR DESCRIPTION
## Summary
- detect mobile devices in `MagazineViewer` and adjust page sizing
- allow `HTMLFlipBook` to switch to portrait mode on small screens
- add manual testing steps for mobile experience

## Testing
- `npm run lint` *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e196ad10832487c72b33ccfc34bc