### PR TITLE
Reset flipbook zoom on window resize

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -61,16 +61,21 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
       setPageSize({ width: newWidth, height: newHeight })
     }
 
+    const handleResize = () => {
+      updateSize()
+      setScale(CLOSED_SCALE)
+      setTranslate(INITIAL_POS)
+    }
     updateSize()
 
     const container = containerRef.current
     const resizeObserver = new ResizeObserver(updateSize)
     if (container) resizeObserver.observe(container)
-    window.addEventListener("resize", updateSize)
+    window.addEventListener("resize", handleResize)
 
     return () => {
       resizeObserver.disconnect()
-      window.removeEventListener("resize", updateSize)
+      window.removeEventListener("resize", handleResize)
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- Reset zoom and position when the window resizes in the magazine viewer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b5762edf288324b1f659568f4ed57b