### PR TITLE
feat: add responsive flipbook component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { ErrorBoundary } from "@/components/error-boundary"
 
 export default function Home() {
   return (
-    <main className="min-h-screen">
+    <main className="h-screen bg-black">
       <ErrorBoundary>
         <ResponsiveFlipBook pages={portfolioPages} />
       </ErrorBoundary>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-import { MagazineViewer } from "@/components/magazine-viewer"
+import ResponsiveFlipBook from "@/components/responsive-book"
 import { portfolioPages } from "@/components/portfolio-pages"
 import { ErrorBoundary } from "@/components/error-boundary"
 
@@ -6,7 +6,7 @@ export default function Home() {
   return (
     <main className="min-h-screen">
       <ErrorBoundary>
-        <MagazineViewer pages={portfolioPages} />
+        <ResponsiveFlipBook pages={portfolioPages} />
       </ErrorBoundary>
     </main>
   )

--- a/components/responsive-book.tsx
+++ b/components/responsive-book.tsx
@@ -49,7 +49,7 @@ export default function ResponsiveFlipBook({ pages }: ResponsiveFlipBookProps) {
   const scaledHeight = BOOK_HEIGHT * scale
 
   return (
-    <div className="relative w-screen h-screen overflow-hidden">
+    <div className="relative w-screen h-screen bg-black overflow-hidden">
       <div
         style={{
           width: BOOK_WIDTH,
@@ -62,7 +62,7 @@ export default function ResponsiveFlipBook({ pages }: ResponsiveFlipBookProps) {
         }}
       >
         <HTMLFlipBook
-          width={BOOK_WIDTH}
+          width={BOOK_WIDTH / 2}
           height={BOOK_HEIGHT}
           showCover
           ref={bookRef}
@@ -75,13 +75,13 @@ export default function ResponsiveFlipBook({ pages }: ResponsiveFlipBookProps) {
         </HTMLFlipBook>
         <button
           onClick={flipPrev}
-          className="absolute top-1/2 left-4 -translate-y-1/2 bg-transparent hover:bg-black/10 text-black p-2 rounded"
+          className="absolute top-1/2 left-4 -translate-y-1/2 z-10 text-white bg-black/40 hover:bg-black/60 p-2 rounded"
         >
           <ChevronLeft />
         </button>
         <button
           onClick={flipNext}
-          className="absolute top-1/2 right-4 -translate-y-1/2 bg-transparent hover:bg-black/10 text-black p-2 rounded"
+          className="absolute top-1/2 right-4 -translate-y-1/2 z-10 text-white bg-black/40 hover:bg-black/60 p-2 rounded"
         >
           <ChevronRight />
         </button>


### PR DESCRIPTION
## Summary
- add ResponsiveFlipBook component leveraging react-pageflip with dynamic scaling to viewport
- replace MagazineViewer usage with ResponsiveFlipBook in home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b57e11d51083248fe137591f20ff36