### PR TITLE
Use container dimensions for magazine sizing

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -50,15 +50,18 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
 
   useEffect(() => {
     const updateSize = () => {
-      const { innerWidth, innerHeight } = window
-      const availableHeight = innerHeight - V_MARGIN * 2
-      let newWidth = innerWidth
+      const container = containerRef.current
+      const containerWidth = container?.clientWidth ?? window.innerWidth
+      const containerHeight = container?.clientHeight ?? window.innerHeight
+      const availableHeight = containerHeight - V_MARGIN * 2
+      let newWidth = containerWidth
       let newHeight = newWidth / PAGE_RATIO
       if (newHeight > availableHeight) {
         newHeight = availableHeight
         newWidth = newHeight * PAGE_RATIO
       }
       setPageSize({ width: newWidth, height: newHeight })
+      setTranslate(INITIAL_POS)
     }
 
     updateSize()


### PR DESCRIPTION
## Summary
- base page size on container dimensions to maintain PAGE_RATIO
- reset translation after resizing to keep flipbook centered

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b6becbd420832483d99c6e7cbf0fbe