### PR TITLE
feat: add responsive flipbook component

### DIFF
--- a/components/ResponsiveFlipBook.tsx
+++ b/components/ResponsiveFlipBook.tsx
@@ -3,14 +3,12 @@
 import { useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 
-// react-pageflip relies on the browser, so load it only on the client
+// react-pageflip doit être chargé uniquement côté client
 const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false });
 
 export interface ResponsiveFlipBookProps {
-  /** URLs for each page image */
   pages: string[];
-  /** width / height ratio of a single page. Defaults to A4 ratio */
-  ratio?: number;
+  ratio?: number; // ratio largeur/hauteur d'une page
 }
 
 export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveFlipBookProps) {
@@ -18,26 +16,24 @@ export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveF
   const [size, setSize] = useState({
     pageWidth: 0,
     pageHeight: 0,
-    bookWidth: 0,
-    bookHeight: 0,
   });
 
-  // Update dimensions on resize to keep the book responsive
+  // calcul dynamique du responsive
   useEffect(() => {
     const updateSize = () => {
       const vw = window.innerWidth;
       const vh = window.innerHeight;
 
-      // compute max page height respecting viewport and ratio
-      const pageHeight = Math.min(vh, vw / (2 * ratio));
-      const pageWidth = pageHeight * ratio;
+      // hauteur max : 90% viewport, largeur max : 95% viewport
+      let pageHeight = vh * 0.9;
+      let pageWidth = pageHeight * ratio;
 
-      setSize({
-        pageWidth,
-        pageHeight,
-        bookWidth: pageWidth * 2,
-        bookHeight: pageHeight,
-      });
+      if (pageWidth * 2 > vw * 0.95) {
+        pageWidth = (vw * 0.95) / 2;
+        pageHeight = pageWidth / ratio;
+      }
+
+      setSize({ pageWidth, pageHeight });
     };
 
     updateSize();
@@ -45,45 +41,50 @@ export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveF
     return () => window.removeEventListener("resize", updateSize);
   }, [ratio]);
 
-  if (!size.bookWidth) return null;
+  if (!size.pageWidth) return null;
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center">
-      <div style={{ width: size.bookWidth, height: size.bookHeight, position: "relative" }}>
-        <HTMLFlipBook
-          ref={bookRef}
-          key={`${size.bookWidth}x${size.bookHeight}`}
-          width={size.pageWidth}
-          height={size.pageHeight}
-          showCover
-          className="shadow-xl"
-          useMouseEvents
-        >
-          {pages.map((src, index) => (
-            <div key={index} className="w-full h-full">
-              <img
-                src={src}
-                alt={`page-${index + 1}`}
-                className="w-full h-full object-cover"
-                draggable={false}
-              />
-            </div>
-          ))}
-        </HTMLFlipBook>
-        {/* Navigation buttons */}
-        <button
-          onClick={() => bookRef.current?.pageFlip().flipPrev()}
-          className="absolute left-0 top-1/2 -translate-y-1/2 bg-black/60 text-white px-3 py-1"
-        >
-          Prev
-        </button>
-        <button
-          onClick={() => bookRef.current?.pageFlip().flipNext()}
-          className="absolute right-0 top-1/2 -translate-y-1/2 bg-black/60 text-white px-3 py-1"
-        >
-          Next
-        </button>
-      </div>
+    <div className="fixed inset-0 flex items-center justify-center bg-black">
+      <HTMLFlipBook
+        ref={bookRef}
+        key={`${size.pageWidth}x${size.pageHeight}`} // force re-render au resize
+        width={size.pageWidth}
+        height={size.pageHeight}
+        size="fixed"
+        minWidth={200}
+        maxWidth={3000}
+        minHeight={200}
+        maxHeight={4000}
+        showCover={true}
+        usePortrait={false} // 🚀 force toujours double page
+        className="shadow-2xl"
+      >
+        {pages.map((src, index) => (
+          <div key={index} className="w-full h-full">
+            <img
+              src={src}
+              alt={`page-${index + 1}`}
+              className="w-full h-full object-cover"
+              draggable={false}
+            />
+          </div>
+        ))}
+      </HTMLFlipBook>
+
+      {/* Boutons navigation */}
+      <button
+        onClick={() => bookRef.current?.pageFlip().flipPrev()}
+        className="absolute left-4 top-1/2 -translate-y-1/2 bg-black/60 text-white px-3 py-1 rounded"
+      >
+        ◀
+      </button>
+      <button
+        onClick={() => bookRef.current?.pageFlip().flipNext()}
+        className="absolute right-4 top-1/2 -translate-y-1/2 bg-black/60 text-white px-3 py-1 rounded"
+      >
+        ▶
+      </button>
     </div>
   );
 }
+

--- a/components/ResponsiveFlipBook.tsx
+++ b/components/ResponsiveFlipBook.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import dynamic from "next/dynamic";
+
+// react-pageflip relies on the browser, so load it only on the client
+const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false });
+
+export interface ResponsiveFlipBookProps {
+  /** URLs for each page image */
+  pages: string[];
+  /** width / height ratio of a single page. Defaults to A4 ratio */
+  ratio?: number;
+}
+
+export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveFlipBookProps) {
+  const bookRef = useRef<any>(null);
+  const [size, setSize] = useState({
+    pageWidth: 0,
+    pageHeight: 0,
+    bookWidth: 0,
+    bookHeight: 0,
+  });
+
+  // Update dimensions on resize to keep the book responsive
+  useEffect(() => {
+    const updateSize = () => {
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+
+      // compute max page height respecting viewport and ratio
+      const pageHeight = Math.min(vh, vw / (2 * ratio));
+      const pageWidth = pageHeight * ratio;
+
+      setSize({
+        pageWidth,
+        pageHeight,
+        bookWidth: pageWidth * 2,
+        bookHeight: pageHeight,
+      });
+    };
+
+    updateSize();
+    window.addEventListener("resize", updateSize);
+    return () => window.removeEventListener("resize", updateSize);
+  }, [ratio]);
+
+  if (!size.bookWidth) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center">
+      <div style={{ width: size.bookWidth, height: size.bookHeight, position: "relative" }}>
+        <HTMLFlipBook
+          ref={bookRef}
+          key={`${size.bookWidth}x${size.bookHeight}`}
+          width={size.pageWidth}
+          height={size.pageHeight}
+          showCover
+          className="shadow-xl"
+          useMouseEvents
+        >
+          {pages.map((src, index) => (
+            <div key={index} className="w-full h-full">
+              <img
+                src={src}
+                alt={`page-${index + 1}`}
+                className="w-full h-full object-cover"
+                draggable={false}
+              />
+            </div>
+          ))}
+        </HTMLFlipBook>
+        {/* Navigation buttons */}
+        <button
+          onClick={() => bookRef.current?.pageFlip().flipPrev()}
+          className="absolute left-0 top-1/2 -translate-y-1/2 bg-black/60 text-white px-3 py-1"
+        >
+          Prev
+        </button>
+        <button
+          onClick={() => bookRef.current?.pageFlip().flipNext()}
+          className="absolute right-0 top-1/2 -translate-y-1/2 bg-black/60 text-white px-3 py-1"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ResponsiveFlipBook` component using `react-pageflip`
- component resizes with window, keeps aspect ratio, stays centered, and includes navigation

## Testing
- `npm run lint` *(interactive prompt: project missing ESLint config)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b6c253982c832493c3ae2a4a896833