### PR TITLE
Refactor ResponsiveFlipBook to update size without re-render

### DIFF
--- a/components/ResponsiveFlipBook.tsx
+++ b/components/ResponsiveFlipBook.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import dynamic from "next/dynamic";
 
 // react-pageflip doit être chargé uniquement côté client
@@ -13,11 +13,6 @@ export interface ResponsiveFlipBookProps {
 
 export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveFlipBookProps) {
   const bookRef = useRef<any>(null);
-  const [size, setSize] = useState({
-    pageWidth: 0,
-    pageHeight: 0,
-  });
-
   // calcul dynamique du responsive
   useEffect(() => {
     const updateSize = () => {
@@ -33,7 +28,7 @@ export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveF
         pageHeight = pageWidth / ratio;
       }
 
-      setSize({ pageWidth, pageHeight });
+      bookRef.current?.pageFlip().update({ width: pageWidth, height: pageHeight });
     };
 
     updateSize();
@@ -41,15 +36,12 @@ export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveF
     return () => window.removeEventListener("resize", updateSize);
   }, [ratio]);
 
-  if (!size.pageWidth) return null;
-
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black">
       <HTMLFlipBook
         ref={bookRef}
-        key={`${size.pageWidth}x${size.pageHeight}`} // force re-render au resize
-        width={size.pageWidth}
-        height={size.pageHeight}
+        width={1}
+        height={1}
         size="fixed"
         minWidth={200}
         maxWidth={3000}


### PR DESCRIPTION
## Summary
- remove state and key-based re-render from `ResponsiveFlipBook`
- update flipbook size via `pageFlip().update` on mount and resize
- initialize `HTMLFlipBook` with placeholder dimensions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d87f569c8324a13249529e30694c