### PR TITLE
Handle container resizing for magazine viewer

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -50,14 +50,24 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
 
   useEffect(() => {
     const updateSize = () => {
-      const { innerWidth, innerHeight } = window
-      const availableHeight = innerHeight - V_MARGIN * 2
-      let newWidth = innerWidth
+      const container = containerRef.current
+      const viewportWidth = window.innerWidth * 0.95
+      const viewportHeight = window.innerHeight * 0.95
+      const maxWidth = container
+        ? Math.min(container.clientWidth, viewportWidth)
+        : viewportWidth
+      const maxHeight = container
+        ? Math.min(container.clientHeight, viewportHeight)
+        : viewportHeight
+
+      let newWidth = maxWidth
       let newHeight = newWidth / PAGE_RATIO
-      if (newHeight > availableHeight) {
-        newHeight = availableHeight
+
+      if (newHeight > maxHeight) {
+        newHeight = maxHeight
         newWidth = newHeight * PAGE_RATIO
       }
+
       setPageSize({ width: newWidth, height: newHeight })
     }
 


### PR DESCRIPTION
## Summary
- Recompute flipbook dimensions on resize using `ResizeObserver` and window listener
- Constrain page size to 95% of viewport while keeping `PAGE_RATIO`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b6de6694dc8324be396b9efaea67cf