### PR TITLE
Disable portrait mode in magazine viewer

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -299,6 +299,9 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
       <HTMLFlipBook
         width={pageWidth}
         height={pageHeight}
+        minWidth={0}
+        minHeight={0}
+        usePortrait={false}
         showCover
         maxShadowOpacity={0.2}
         drawShadow


### PR DESCRIPTION
## Summary
- prevent HTMLFlipBook from switching to portrait by setting `usePortrait` to false
- lock flip book to landscape mode at any size with minimal width/height

## Testing
- `npm run lint` *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b6de69a9d08324bd4da86e04fec392