### PR TITLE
feat: add responsive flip book component

### DIFF
--- a/components/ResponsiveFlipBook.tsx
+++ b/components/ResponsiveFlipBook.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import type { ReactNode } from "react"
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import dynamic from "next/dynamic"
-import type { default as FlipBook } from "react-pageflip"
+import type HTMLFlipBookType from "react-pageflip"
 
 const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false })
 
@@ -31,7 +31,7 @@ export function ResponsiveFlipBook({
   className,
 }: ResponsiveFlipBookProps) {
   const containerRef = useRef<HTMLDivElement>(null)
-  const bookRef = useRef<FlipBook | null>(null)
+  const bookRef = useRef<HTMLFlipBookType | null>(null)
   const [{ pageWidth, pageHeight, left, top }, setLayout] = useState({
     pageWidth: 0,
     pageHeight: 0,
@@ -39,7 +39,7 @@ export function ResponsiveFlipBook({
     top: 0,
   })
 
-  const updateLayout = () => {
+  const updateLayout = useCallback(() => {
     const container = containerRef.current
     if (!container) return
     const cw = container.clientWidth
@@ -89,7 +89,15 @@ export function ResponsiveFlipBook({
         top: newTop,
       }
     })
-  }
+  }, [
+    marginLeftRatio,
+    marginRightRatio,
+    marginTopRatio,
+    marginBottomRatio,
+    pageAspectRatio,
+    maxBookWidth,
+    maxBookHeight,
+  ])
 
   useEffect(() => {
     updateLayout()
@@ -109,15 +117,7 @@ export function ResponsiveFlipBook({
         window.removeEventListener("resize", updateLayout)
       }
     }
-  }, [
-    pageAspectRatio,
-    marginLeftRatio,
-    marginRightRatio,
-    marginTopRatio,
-    marginBottomRatio,
-    maxBookWidth,
-    maxBookHeight,
-  ])
+  }, [updateLayout])
 
   useEffect(() => {
     if (bookRef.current) {


### PR DESCRIPTION
## Summary
- implement ResponsiveFlipBook with margin ratios and dynamic sizing
- update layout using ResizeObserver and window resize fallback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b6f3072c788324a0e8323837e5e1b2