### PR TITLE
feat: add margin to responsive flipbook

### DIFF
--- a/components/ResponsiveFlipBook.tsx
+++ b/components/ResponsiveFlipBook.tsx
@@ -21,15 +21,15 @@ export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveF
   // calcul dynamique du responsive
   useEffect(() => {
     const updateSize = () => {
-      const vw = window.innerWidth;
-      const vh = window.innerHeight;
+      const marginRatio = 0.05;
+      const availableWidth = window.innerWidth * (1 - marginRatio * 2);
+      const availableHeight = window.innerHeight * (1 - marginRatio * 2);
 
-      // hauteur max : 90% viewport, largeur max : 95% viewport
-      let pageHeight = vh * 0.9;
+      let pageHeight = availableHeight;
       let pageWidth = pageHeight * ratio;
 
-      if (pageWidth * 2 > vw * 0.95) {
-        pageWidth = (vw * 0.95) / 2;
+      if (pageWidth * 2 > availableWidth) {
+        pageWidth = availableWidth / 2;
         pageHeight = pageWidth / ratio;
       }
 


### PR DESCRIPTION
## Summary
- compute available viewport size with uniform margins for ResponsiveFlipBook
- scale pages based on available width and height while keeping aspect ratio

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ff60f3a483249f288f8fb32253f5