### PR TITLE
feat: add responsive flipbook with fullscreen demo

### DIFF
--- a/app/flipbook-demo/page.tsx
+++ b/app/flipbook-demo/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import ResponsiveFlipBook from "@/components/ResponsiveFlipBook";
+
+export default function FlipbookDemoPage() {
+  const pages = [
+    <div className="w-full h-full flex items-center justify-center bg-gray-200" key="p1">
+      Page 1
+    </div>,
+    <div className="w-full h-full flex items-center justify-center bg-gray-300" key="p2">
+      Page 2
+    </div>,
+    <div className="w-full h-full flex items-center justify-center bg-gray-400" key="p3">
+      Page 3
+    </div>,
+    <div className="w-full h-full flex items-center justify-center bg-gray-500" key="p4">
+      Page 4
+    </div>,
+  ];
+
+  const enterFullscreen = () => {
+    document.documentElement.requestFullscreen();
+  };
+
+  const exitFullscreen = () => {
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    }
+  };
+
+  return (
+    <div className="w-full h-[100dvh] flex flex-col">
+      <div className="p-2 flex gap-2">
+        <button
+          onClick={enterFullscreen}
+          className="px-4 py-2 border rounded"
+        >
+          Plein écran
+        </button>
+        <button
+          onClick={exitFullscreen}
+          className="px-4 py-2 border rounded"
+        >
+          Quitter
+        </button>
+      </div>
+      <div className="flex-1">
+        <ResponsiveFlipBook pages={pages} />
+      </div>
+    </div>
+  );
+}
+

--- a/components/ResponsiveFlipBook.tsx
+++ b/components/ResponsiveFlipBook.tsx
@@ -13,6 +13,7 @@ export interface ResponsiveFlipBookProps {
   marginBottomPercent?: number;
   fullscreenMarginTopPercent?: number;
   fullscreenMarginBottomPercent?: number;
+  fullscreenScale?: number;
   className?: string;
 }
 
@@ -30,6 +31,7 @@ export default function ResponsiveFlipBook({
   marginBottomPercent = 6,
   fullscreenMarginTopPercent = 5,
   fullscreenMarginBottomPercent = 5,
+  fullscreenScale = 1.1,
   className,
 }: ResponsiveFlipBookProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -121,21 +123,29 @@ export default function ResponsiveFlipBook({
       style={{ paddingTop: size.marginTop, paddingBottom: size.marginBottom }}
     >
       {size.pageWidth > 0 && (
-        <HTMLFlipBook
-          ref={bookRef}
-          width={size.pageWidth}
-          height={size.pageHeight}
-          size="fixed"
-          autoSize={false}
-          usePortrait={false}
-          className="shadow-2xl"
+        <div
+          style={{
+            transform: isFullscreen ? `scale(${fullscreenScale})` : "scale(1)",
+            transformOrigin: "top center",
+            transition: "transform 0.2s",
+          }}
         >
-          {pages.map((page, idx) => (
-            <div key={idx} className="w-full h-full">
-              {page}
-            </div>
-          ))}
-        </HTMLFlipBook>
+          <HTMLFlipBook
+            ref={bookRef}
+            width={size.pageWidth}
+            height={size.pageHeight}
+            size="fixed"
+            autoSize={false}
+            usePortrait={false}
+            className="shadow-2xl"
+          >
+            {pages.map((page, idx) => (
+              <div key={idx} className="w-full h-full">
+                {page}
+              </div>
+            ))}
+          </HTMLFlipBook>
+        </div>
       )}
     </div>
   );

--- a/components/ResponsiveFlipBook.tsx
+++ b/components/ResponsiveFlipBook.tsx
@@ -2,88 +2,141 @@
 
 import { useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
+import { cn } from "@/lib/utils";
 
-// react-pageflip doit être chargé uniquement côté client
-const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false });
+const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false }) as any;
 
 export interface ResponsiveFlipBookProps {
-  pages: string[];
-  ratio?: number; // ratio largeur/hauteur d'une page
+  pages: React.ReactNode[];
+  pageAspectRatio?: number; // height / width of a single page
+  marginTopPercent?: number;
+  marginBottomPercent?: number;
+  fullscreenMarginTopPercent?: number;
+  fullscreenMarginBottomPercent?: number;
+  className?: string;
 }
 
-export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveFlipBookProps) {
+interface BookSize {
+  pageWidth: number;
+  pageHeight: number;
+  marginTop: number;
+  marginBottom: number;
+}
+
+export default function ResponsiveFlipBook({
+  pages,
+  pageAspectRatio = 1.333,
+  marginTopPercent = 6,
+  marginBottomPercent = 6,
+  fullscreenMarginTopPercent = 5,
+  fullscreenMarginBottomPercent = 5,
+  className,
+}: ResponsiveFlipBookProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
   const bookRef = useRef<any>(null);
-  const [size, setSize] = useState({
+  const [size, setSize] = useState<BookSize>({
     pageWidth: 0,
     pageHeight: 0,
+    marginTop: 0,
+    marginBottom: 0,
   });
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
-  // calcul dynamique du responsive
   useEffect(() => {
-    const updateSize = () => {
-      const vw = window.innerWidth;
-      const vh = window.innerHeight;
-
-      // hauteur max : 90% viewport, largeur max : 95% viewport
-      let pageHeight = vh * 0.9;
-      let pageWidth = pageHeight * ratio;
-
-      if (pageWidth * 2 > vw * 0.95) {
-        pageWidth = (vw * 0.95) / 2;
-        pageHeight = pageWidth / ratio;
-      }
-
-      setSize({ pageWidth, pageHeight });
+    const handleFullscreenChange = () => {
+      const element = document.fullscreenElement || (document as any).webkitFullscreenElement;
+      setIsFullscreen(Boolean(element));
     };
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    document.addEventListener("webkitfullscreenchange", handleFullscreenChange as any);
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+      document.removeEventListener("webkitfullscreenchange", handleFullscreenChange as any);
+    };
+  }, []);
 
-    updateSize();
-    window.addEventListener("resize", updateSize);
-    return () => window.removeEventListener("resize", updateSize);
-  }, [ratio]);
+  const computeSize = (width: number, height: number) => {
+    const topPercent = isFullscreen ? fullscreenMarginTopPercent : marginTopPercent;
+    const bottomPercent = isFullscreen ? fullscreenMarginBottomPercent : marginBottomPercent;
 
-  if (!size.pageWidth) return null;
+    const marginTop = (topPercent / 100) * height;
+    const marginBottom = (bottomPercent / 100) * height;
+    let usableHeight = height - marginTop - marginBottom;
+    let pageHeight = usableHeight;
+    let pageWidth = pageHeight / pageAspectRatio;
+
+    if (pageWidth * 2 > width) {
+      pageWidth = width / 2;
+      pageHeight = pageWidth * pageAspectRatio;
+    }
+
+    const newSize: BookSize = { pageWidth, pageHeight, marginTop, marginBottom };
+    setSize((prev) => {
+      if (
+        prev.pageWidth === newSize.pageWidth &&
+        prev.pageHeight === newSize.pageHeight &&
+        prev.marginTop === newSize.marginTop &&
+        prev.marginBottom === newSize.marginBottom
+      ) {
+        return prev;
+      }
+      requestAnimationFrame(() => {
+        bookRef.current?.pageFlip().update();
+      });
+      return newSize;
+    });
+  };
+
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+
+    const handleResize = () => computeSize(node.clientWidth, node.clientHeight);
+    handleResize();
+
+    let ro: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      ro = new ResizeObserver(() => handleResize());
+      ro.observe(node);
+    }
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      ro?.disconnect();
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [
+    isFullscreen,
+    pageAspectRatio,
+    marginTopPercent,
+    marginBottomPercent,
+    fullscreenMarginTopPercent,
+    fullscreenMarginBottomPercent,
+  ]);
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black">
-      <HTMLFlipBook
-        ref={bookRef}
-        key={`${size.pageWidth}x${size.pageHeight}`} // force re-render au resize
-        width={size.pageWidth}
-        height={size.pageHeight}
-        size="fixed"
-        minWidth={200}
-        maxWidth={3000}
-        minHeight={200}
-        maxHeight={4000}
-        showCover={true}
-        usePortrait={false} // 🚀 force toujours double page
-        className="shadow-2xl"
-      >
-        {pages.map((src, index) => (
-          <div key={index} className="w-full h-full">
-            <img
-              src={src}
-              alt={`page-${index + 1}`}
-              className="w-full h-full object-cover"
-              draggable={false}
-            />
-          </div>
-        ))}
-      </HTMLFlipBook>
-
-      {/* Boutons navigation */}
-      <button
-        onClick={() => bookRef.current?.pageFlip().flipPrev()}
-        className="absolute left-4 top-1/2 -translate-y-1/2 bg-black/60 text-white px-3 py-1 rounded"
-      >
-        ◀
-      </button>
-      <button
-        onClick={() => bookRef.current?.pageFlip().flipNext()}
-        className="absolute right-4 top-1/2 -translate-y-1/2 bg-black/60 text-white px-3 py-1 rounded"
-      >
-        ▶
-      </button>
+    <div
+      ref={containerRef}
+      className={cn("w-full h-full flex justify-center", className)}
+      style={{ paddingTop: size.marginTop, paddingBottom: size.marginBottom }}
+    >
+      {size.pageWidth > 0 && (
+        <HTMLFlipBook
+          ref={bookRef}
+          width={size.pageWidth}
+          height={size.pageHeight}
+          size="fixed"
+          autoSize={false}
+          usePortrait={false}
+          className="shadow-2xl"
+        >
+          {pages.map((page, idx) => (
+            <div key={idx} className="w-full h-full">
+              {page}
+            </div>
+          ))}
+        </HTMLFlipBook>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement responsive flipbook that grows slightly in fullscreen using margin-based sizing
- add demo page showing fullscreen controls

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b74a7fcf5883248d4149489042555a