### PR TITLE
feat: add device type hook

### DIFF
--- a/hooks/useDeviceType.ts
+++ b/hooks/useDeviceType.ts
@@ -1,0 +1,47 @@
+import * as React from "react"
+
+interface DeviceType {
+  isMobile: boolean
+  isTablet: boolean
+  isDesktop: boolean
+}
+
+export function useDeviceType() {
+  const [device, setDevice] = React.useState<DeviceType>({
+    isMobile: false,
+    isTablet: false,
+    isDesktop: false,
+  })
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const pointerQuery = window.matchMedia("(pointer: coarse)")
+    const widthQuery = window.matchMedia("(max-width: 768px)")
+
+    const update = () => {
+      const ua = navigator.userAgent
+      const isTablet = /Tablet|iPad/i.test(ua)
+      const isMobile =
+        (!isTablet && /Mobi|Android/i.test(ua)) || pointerQuery.matches || widthQuery.matches
+      const isDesktop = !isMobile && !isTablet
+
+      setDevice({ isMobile, isTablet, isDesktop })
+    }
+
+    update()
+
+    window.addEventListener("resize", update)
+    pointerQuery.addEventListener("change", update)
+    widthQuery.addEventListener("change", update)
+
+    return () => {
+      window.removeEventListener("resize", update)
+      pointerQuery.removeEventListener("change", update)
+      widthQuery.removeEventListener("change", update)
+    }
+  }, [])
+
+  return device
+}
+


### PR DESCRIPTION
## Summary
- add `useDeviceType` hook to detect mobile, tablet, and desktop via user agent and media queries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b7636643188324870c1e8f36b5b75f