### PR TITLE
feat: add flipbook page with orientation guard

### DIFF
--- a/app/flipbook/page.tsx
+++ b/app/flipbook/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useRef } from "react";
+import ResponsiveFlipBook from "@/components/ResponsiveFlipBook";
+import LandscapeGuard from "@/components/landscape-guard";
+
+export default function FlipbookPage() {
+  const fullscreenRef = useRef<HTMLDivElement>(null);
+  const pages = ["/images/PAGE 6.png", "/images/PAGE 7.png"];
+
+  const requestFullscreenAndLockLandscape = async () => {
+    const el = fullscreenRef.current;
+    if (!el) return;
+    try {
+      await el.requestFullscreen();
+      // Try to lock orientation if API is available
+      // @ts-ignore
+      await screen.orientation?.lock?.("landscape");
+    } catch (err) {
+      console.warn("Failed to enter fullscreen", err);
+    }
+  };
+
+  return (
+    <div className="w-full h-[100dvh]" ref={fullscreenRef}>
+      <LandscapeGuard enableOnMobile fullscreenTargetRef={fullscreenRef}>
+        <ResponsiveFlipBook pages={pages} />
+      </LandscapeGuard>
+      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2">
+        <button
+          onClick={requestFullscreenAndLockLandscape}
+          className="px-3 py-1 bg-white/20 text-white rounded"
+        >
+          Enter fullscreen
+        </button>
+        <button
+          onClick={() => document.exitFullscreen()}
+          className="px-3 py-1 bg-white/20 text-white rounded"
+        >
+          Exit fullscreen
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/components/landscape-guard.tsx
+++ b/components/landscape-guard.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState, useRef, type RefObject } from "react";
+
+interface LandscapeGuardProps {
+  children: React.ReactNode;
+  enableOnMobile?: boolean;
+  fullscreenTargetRef?: RefObject<HTMLDivElement>;
+}
+
+/**
+ * A simple guard that displays a rotate device message on mobile portrait
+ * orientations. It also forwards the provided ref to the wrapping div so it can
+ * be used as a target for fullscreen requests.
+ */
+export default function LandscapeGuard({
+  children,
+  enableOnMobile = false,
+  fullscreenTargetRef,
+}: LandscapeGuardProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isLandscape, setIsLandscape] = useState(true);
+
+  useEffect(() => {
+    const target = fullscreenTargetRef ?? containerRef;
+    if (fullscreenTargetRef) {
+      (fullscreenTargetRef as any).current = target.current;
+    }
+  }, [fullscreenTargetRef]);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(orientation: landscape)");
+    const handleChange = () => setIsLandscape(mql.matches);
+    handleChange();
+    mql.addEventListener("change", handleChange);
+    return () => mql.removeEventListener("change", handleChange);
+  }, []);
+
+  if (enableOnMobile && !isLandscape) {
+    return (
+      <div
+        ref={containerRef}
+        className="flex items-center justify-center w-full h-full"
+      >
+        <p className="text-center">Please rotate your device</p>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={fullscreenTargetRef ?? containerRef} className="w-full h-full">
+      {children}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add client flipbook page with fullscreen container and test controls
- introduce LandscapeGuard component for simple orientation handling

## Testing
- `pnpm run test` (fails: Missing script: test)
- `pnpm run lint` (fails: Command failed with exit code 1)


------
https://chatgpt.com/codex/tasks/task_e_68b7638d41f483248b4d900a68a02519