### PR TITLE
feat: add landscape orientation guard

### DIFF
--- a/components/LandscapeGuard.tsx
+++ b/components/LandscapeGuard.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import * as React from "react"
+import { RotateCcw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useDeviceType } from "@/hooks/use-device-type"
+import { useOrientation } from "@/hooks/use-orientation"
+import { cn } from "@/lib/utils"
+
+interface LandscapeGuardProps {
+  children: React.ReactNode
+  enableOnMobile?: boolean
+  fullscreenTargetRef?: React.RefObject<HTMLElement>
+}
+
+export function LandscapeGuard({
+  children,
+  enableOnMobile = true,
+  fullscreenTargetRef,
+}: LandscapeGuardProps) {
+  const deviceType = useDeviceType()
+  const isMobile = deviceType === "mobile"
+  const { orientation, requestFullscreenAndLockLandscape } = useOrientation()
+
+  const showOverlay = enableOnMobile && isMobile && orientation === "portrait"
+
+  const canLockOrientation =
+    typeof screen !== "undefined" && !!screen.orientation && !!screen.orientation.lock
+
+  return (
+    <div className="relative">
+      {children}
+      <div
+        className={cn(
+          "absolute inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-black/80 text-white transition-opacity duration-300",
+          showOverlay ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+      >
+        <RotateCcw className="h-12 w-12" />
+        <p className="text-lg font-medium">Tournez votre appareil</p>
+        {canLockOrientation ? (
+          <Button
+            onClick={() =>
+              requestFullscreenAndLockLandscape(fullscreenTargetRef?.current ?? undefined)
+            }
+          >
+            Plein écran & verrouiller en paysage
+          </Button>
+        ) : (
+          <p className="max-w-xs text-center text-sm opacity-80">
+            Le verrouillage d'orientation n'est pas disponible. Passez en paysage
+            manuellement.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/hooks/use-device-type.ts
+++ b/hooks/use-device-type.ts
@@ -1,0 +1,9 @@
+import { useIsMobile } from "@/hooks/use-mobile"
+
+export type DeviceType = "mobile" | "desktop"
+
+export function useDeviceType(): DeviceType {
+  const isMobile = useIsMobile()
+  return isMobile ? "mobile" : "desktop"
+}
+

--- a/hooks/use-orientation.ts
+++ b/hooks/use-orientation.ts
@@ -1,0 +1,39 @@
+import * as React from "react"
+
+export type Orientation = "portrait" | "landscape"
+
+function getOrientation(): Orientation {
+  if (typeof window === "undefined") return "portrait"
+  return window.matchMedia("(orientation: portrait)").matches ? "portrait" : "landscape"
+}
+
+export function useOrientation() {
+  const [orientation, setOrientation] = React.useState<Orientation>(getOrientation())
+
+  React.useEffect(() => {
+    const handler = () => setOrientation(getOrientation())
+    window.addEventListener("orientationchange", handler)
+    window.addEventListener("resize", handler)
+    return () => {
+      window.removeEventListener("orientationchange", handler)
+      window.removeEventListener("resize", handler)
+    }
+  }, [])
+
+  const requestFullscreenAndLockLandscape = React.useCallback(async (element?: HTMLElement | null) => {
+    const target = element ?? document.documentElement
+    if (target.requestFullscreen) {
+      await target.requestFullscreen()
+    }
+    if (screen.orientation && screen.orientation.lock) {
+      try {
+        await screen.orientation.lock("landscape")
+      } catch (e) {
+        // ignore
+      }
+    }
+  }, [])
+
+  return { orientation, requestFullscreenAndLockLandscape }
+}
+


### PR DESCRIPTION
## Summary
- add LandscapeGuard component to guide users to landscape orientation
- provide device type and orientation hooks

## Testing
- `pnpm lint` *(fails: asks interactive configuration)*
- `pnpm build` *(fails: cannot fetch google font files)*

------
https://chatgpt.com/codex/tasks/task_e_68b7637c219c8324ab1bc01da05c8c28