### PR TITLE
feat: improve flipbook interactivity

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -212,6 +212,13 @@
   transition-delay: 0.1s;
 }
 
+/* Ensure interactive elements remain clickable when zoomed */
+.flipbook button,
+.flipbook a,
+.flipbook .book-clickable {
+  pointer-events: auto;
+}
+
 /* Blue pulse animation for clickable book buttons */
 @keyframes blue-pulse {
   0%,

--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -150,19 +150,27 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
     setCurrentPage(page)
   }
 
+  const isInteractiveElement = (target: EventTarget | null) => {
+    return (
+      target instanceof HTMLElement &&
+      target.closest("button, a, .book-clickable") !== null
+    )
+  }
+
   const startDragging = (clientX: number, clientY: number) => {
     setIsDragging(true)
     lastPointer.current = { x: clientX, y: clientY }
   }
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (scale <= OPEN_SCALE) return
+    if (scale <= OPEN_SCALE || isInteractiveElement(e.target)) return
     startDragging(e.clientX, e.clientY)
   }
 
   const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
     if (scale <= OPEN_SCALE) return
     const touch = e.touches[0]
+    if (isInteractiveElement(touch.target)) return
     startDragging(touch.clientX, touch.clientY)
   }
 


### PR DESCRIPTION
## Summary
- avoid starting drag when clicking interactive elements
- ensure zoomed flipbook keeps clickable elements responsive

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b77852aa748324be8952b23a2f0806