### PR TITLE
Disable flipbook effects when zoomed

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -48,14 +48,16 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
       ? pageWidth / 2
       : 0
 
-  const { showPageCorners, drawShadow, maxShadowOpacity } = useMemo(() => {
-    const enabled = scale <= OPEN_SCALE
-    return {
-      showPageCorners: enabled,
-      drawShadow: enabled,
-      maxShadowOpacity: enabled ? 0.2 : 0,
-    }
-  }, [scale])
+  const { showPageCorners, drawShadow, maxShadowOpacity, useMouseEvents } =
+    useMemo(() => {
+      const enabled = scale <= OPEN_SCALE
+      return {
+        showPageCorners: enabled,
+        drawShadow: enabled,
+        maxShadowOpacity: enabled ? 0.2 : 0,
+        useMouseEvents: enabled,
+      }
+    }, [scale])
 
   useEffect(() => {
     const updateSize = () => {
@@ -84,14 +86,17 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
   }, [])
 
   const handleNextPage = () => {
+    if (scale > OPEN_SCALE) return
     bookRef.current?.pageFlip()?.flipNext()
   }
 
   const handlePrevPage = () => {
+    if (scale > OPEN_SCALE) return
     bookRef.current?.pageFlip()?.flipPrev()
   }
 
   const goToPage = (page: number) => {
+    if (scale > OPEN_SCALE) return
     bookRef.current?.pageFlip()?.flip(page - 1)
   }
 
@@ -317,6 +322,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         maxShadowOpacity={maxShadowOpacity}
         flippingTime={FLIP_DURATION}
         disableFlipByClick
+        useMouseEvents={useMouseEvents}
         swipeDistance={30}
         className="shadow-md flipbook"
         ref={bookRef}

--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { useState, useRef, useEffect, useCallback } from "react"
+import { useState, useRef, useEffect, useCallback, useMemo } from "react"
 import { Plus, Minus, ChevronLeft, ChevronRight } from "lucide-react"
 import dynamic from "next/dynamic"
 import { Button } from "@/components/ui/button"
@@ -47,6 +47,15 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
       : currentPage === totalPages - 1
       ? pageWidth / 2
       : 0
+
+  const { showPageCorners, drawShadow, maxShadowOpacity } = useMemo(() => {
+    const enabled = scale <= OPEN_SCALE
+    return {
+      showPageCorners: enabled,
+      drawShadow: enabled,
+      maxShadowOpacity: enabled ? 0.2 : 0,
+    }
+  }, [scale])
 
   useEffect(() => {
     const updateSize = () => {
@@ -303,10 +312,10 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         minHeight={0}
         usePortrait={false}
         showCover
-        maxShadowOpacity={0.2}
-        drawShadow
+        showPageCorners={showPageCorners}
+        drawShadow={drawShadow}
+        maxShadowOpacity={maxShadowOpacity}
         flippingTime={FLIP_DURATION}
-        showPageCorners
         disableFlipByClick
         swipeDistance={30}
         className="shadow-md flipbook"


### PR DESCRIPTION
## Summary
- recompute page corner and shadow props based on zoom scale
- disable flipbook visual effects when scale exceeds 1

## Testing
- `npm test` (fails: missing script)
- `npm run lint` (prompted for ESLint config)

------
https://chatgpt.com/codex/tasks/task_e_68b7785a18d88324aea9dc433e040f74