### PR TITLE
Use relative units for portfolio link button

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -147,7 +147,7 @@ const bjornChapterPages = [
           <Button
             variant="outline"
             highlight
-            className="absolute left-[37%] bottom-[17%] z-10 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
+            className="absolute left-[37%] bottom-[17%] z-10 w-[15%] h-[5%] p-0 rounded-none border border-[#1C1C1C] bg-white font-sora text-[75%] text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
           >
             visiter le site
           </Button>


### PR DESCRIPTION
## Summary
- replace pixel-based button sizing in portfolio pages with percentage width/height and relative font size

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint setup)*
- `npm run build` *(fails: Failed to fetch `Montserrat`, `Open Sans`, `Sora` from Google Fonts)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b7785b42e08324afde564dd2417791