### PR TITLE
Auto-lock landscape orientation on mobile

### DIFF
--- a/components/LandscapeGuard.tsx
+++ b/components/LandscapeGuard.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react"
 import { RotateCcw } from "lucide-react"
-import { Button } from "@/components/ui/button"
 import { useDeviceType } from "@/hooks/use-device-type"
 import { useOrientation } from "@/hooks/use-orientation"
 import { cn } from "@/lib/utils"
@@ -22,36 +21,25 @@ export function LandscapeGuard({
   const isMobile = deviceType === "mobile"
   const { orientation, requestFullscreenAndLockLandscape } = useOrientation()
 
-  const showOverlay = enableOnMobile && isMobile && orientation === "portrait"
+  React.useEffect(() => {
+    if (isMobile) {
+      requestFullscreenAndLockLandscape(fullscreenTargetRef?.current ?? undefined)
+    }
+  }, [isMobile, requestFullscreenAndLockLandscape, fullscreenTargetRef])
 
-  const canLockOrientation =
-    typeof screen !== "undefined" && !!screen.orientation && !!screen.orientation.lock
+  const showOverlay = enableOnMobile && isMobile && orientation === "portrait"
 
   return (
     <div className="relative">
       {children}
       <div
         className={cn(
-          "absolute inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-black/80 text-white transition-opacity duration-300",
+          "fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-black/80 text-white transition-opacity duration-300",
           showOverlay ? "opacity-100" : "pointer-events-none opacity-0",
         )}
       >
         <RotateCcw className="h-12 w-12" />
         <p className="text-lg font-medium">Tournez votre appareil</p>
-        {canLockOrientation ? (
-          <Button
-            onClick={() =>
-              requestFullscreenAndLockLandscape(fullscreenTargetRef?.current ?? undefined)
-            }
-          >
-            Plein écran & verrouiller en paysage
-          </Button>
-        ) : (
-          <p className="max-w-xs text-center text-sm opacity-80">
-            Le verrouillage d'orientation n'est pas disponible. Passez en paysage
-            manuellement.
-          </p>
-        )}
       </div>
     </div>
   )

--- a/hooks/use-orientation.ts
+++ b/hooks/use-orientation.ts
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { useIsMobile } from "@/hooks/use-mobile"
 
 export type Orientation = "portrait" | "landscape"
 
@@ -9,6 +10,7 @@ function getOrientation(): Orientation {
 
 export function useOrientation() {
   const [orientation, setOrientation] = React.useState<Orientation>(getOrientation())
+  const isMobile = useIsMobile()
 
   React.useEffect(() => {
     const handler = () => setOrientation(getOrientation())
@@ -20,19 +22,28 @@ export function useOrientation() {
     }
   }, [])
 
-  const requestFullscreenAndLockLandscape = React.useCallback(async (element?: HTMLElement | null) => {
-    const target = element ?? document.documentElement
-    if (target.requestFullscreen) {
-      await target.requestFullscreen()
-    }
-    if (screen.orientation && screen.orientation.lock) {
-      try {
-        await screen.orientation.lock("landscape")
-      } catch (e) {
-        // ignore
+  const requestFullscreenAndLockLandscape = React.useCallback(
+    async (element?: HTMLElement | null) => {
+      const target = element ?? document.documentElement
+      if (!document.fullscreenElement && target.requestFullscreen) {
+        await target.requestFullscreen()
       }
+      if (screen.orientation && screen.orientation.lock) {
+        try {
+          await screen.orientation.lock("landscape")
+        } catch (e) {
+          // ignore
+        }
+      }
+    },
+    [],
+  )
+
+  React.useEffect(() => {
+    if (isMobile) {
+      requestFullscreenAndLockLandscape()
     }
-  }, [])
+  }, [isMobile, requestFullscreenAndLockLandscape])
 
   return { orientation, requestFullscreenAndLockLandscape }
 }


### PR DESCRIPTION
## Summary
- Auto-request fullscreen and lock orientation on mobile devices
- Block UI with rotate overlay in portrait mode

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b7786658ec83248e92b4887a366487