### PR TITLE
Stop book button animation from replaying

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -225,6 +225,7 @@
 
 .book-clickable {
   animation: blue-pulse 2s ease-in-out 2;
+  animation-fill-mode: forwards;
   background: white;
   color: black;
   border: 1px solid black;

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -147,6 +147,7 @@ const bjornChapterPages = [
           <Button
             variant="outline"
             highlight
+            onAnimationEnd={(e) => e.currentTarget.classList.remove("book-clickable")}
             className="absolute left-[37%] bottom-[17%] z-10 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
           >
             visiter le site


### PR DESCRIPTION
## Summary
- remove `book-clickable` class once the book button animation completes
- keep animated button in its final state with `animation-fill-mode: forwards`

## Testing
- `npm ci --legacy-peer-deps`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b7786a8fc083249a24606afbb4c4cf