### PR TITLE
Fix button dimensions for portfolio page link

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -147,7 +147,7 @@ const bjornChapterPages = [
           <Button
             variant="outline"
             highlight
-            className="absolute left-[37%] bottom-[17%] z-10 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
+            className="absolute left-[37%] bottom-[17%] z-10 rounded-none border border-[#1C1C1C] bg-white px-8 py-3 w-[704px] h-[180px] font-sora text-xs text-[#1C1C1C] hover:bg-[#1C1C1C] hover:text-white"
           >
             visiter le site
           </Button>


### PR DESCRIPTION
## Summary
- enforce fixed width and height for the "visiter le site" button on portfolio page 17

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `node -e "...puppeteer script..."` *(fails: missing system libraries for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f890b18832494f3cea00847a65e