### PR TITLE
feat: add loading overlay for flipbook

### DIFF
--- a/app/flipbook/page.tsx
+++ b/app/flipbook/page.tsx
@@ -1,12 +1,31 @@
 "use client";
 
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import ResponsiveFlipBook from "@/components/ResponsiveFlipBook";
 import LandscapeGuard from "@/components/landscape-guard";
+import Loader from "@/components/loader";
 
 export default function FlipbookPage() {
   const fullscreenRef = useRef<HTMLDivElement>(null);
   const pages = ["/images/PAGE 6.png", "/images/PAGE 7.png"];
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loadImages = async () => {
+      const promises = pages.map(
+        (src) =>
+          new Promise<void>((resolve) => {
+            const img = new Image();
+            img.src = src;
+            img.onload = () => resolve();
+            img.onerror = () => resolve();
+          })
+      );
+      await Promise.all(promises);
+      setIsLoading(false);
+    };
+    loadImages();
+  }, [pages]);
 
   const requestFullscreenAndLockLandscape = async () => {
     const el = fullscreenRef.current;
@@ -24,22 +43,25 @@ export default function FlipbookPage() {
   return (
     <div className="w-full h-[100dvh]" ref={fullscreenRef}>
       <LandscapeGuard enableOnMobile fullscreenTargetRef={fullscreenRef}>
-        <ResponsiveFlipBook pages={pages} />
+        {!isLoading && <ResponsiveFlipBook pages={pages} />}
       </LandscapeGuard>
-      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2">
-        <button
-          onClick={requestFullscreenAndLockLandscape}
-          className="px-3 py-1 bg-white/20 text-white rounded"
-        >
-          Enter fullscreen
-        </button>
-        <button
-          onClick={() => document.exitFullscreen()}
-          className="px-3 py-1 bg-white/20 text-white rounded"
-        >
-          Exit fullscreen
-        </button>
-      </div>
+      {!isLoading && (
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2">
+          <button
+            onClick={requestFullscreenAndLockLandscape}
+            className="px-3 py-1 bg-white/20 text-white rounded"
+          >
+            Enter fullscreen
+          </button>
+          <button
+            onClick={() => document.exitFullscreen()}
+            className="px-3 py-1 bg-white/20 text-white rounded"
+          >
+            Exit fullscreen
+          </button>
+        </div>
+      )}
+      {isLoading && <Loader />}
     </div>
   );
 }

--- a/components/loader.tsx
+++ b/components/loader.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+export default function Loader() {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-gradient-to-br from-orange-100 via-pink-100 to-orange-200">
+      <div className="relative">
+        <div className="w-16 h-16 rounded-full border-4 border-orange-500 border-t-transparent animate-spin"></div>
+        <span className="absolute inset-0 flex items-center justify-center font-bold text-orange-500">
+          ciao
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create kombucha-inspired loader overlay
- hide flipbook until images finish loading

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build` *(fails: failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aadea1548324a06dd2a3085e5c66