### PR TITLE
feat: add Cloudinary icons metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,6 +26,36 @@ export const metadata: Metadata = {
   description:
     "Interactive digital magazine portfolio showcasing branding, packaging, illustration, and web & motion design work.",
   generator: "v0.app",
+  icons: {
+    icon: [
+      {
+        rel: "icon",
+        type: "image/png",
+        sizes: "16x16",
+        url: "https://res.cloudinary.com/dakxjcdyp/image/upload/c_fill,w_16,h_16/v1757931408/Nouvelle-pp-bon_qqdkrb.png",
+      },
+      {
+        rel: "icon",
+        type: "image/png",
+        sizes: "32x32",
+        url: "https://res.cloudinary.com/dakxjcdyp/image/upload/c_fill,w_32,h_32/v1757931408/Nouvelle-pp-bon_qqdkrb.png",
+      },
+      {
+        rel: "icon",
+        type: "image/png",
+        sizes: "512x512",
+        url: "https://res.cloudinary.com/dakxjcdyp/image/upload/c_fill,w_512,h_512/v1757931408/Nouvelle-pp-bon_qqdkrb.png",
+      },
+    ],
+    apple: [
+      {
+        rel: "apple-touch-icon",
+        type: "image/png",
+        sizes: "180x180",
+        url: "https://res.cloudinary.com/dakxjcdyp/image/upload/c_fill,w_180,h_180/v1757931408/Nouvelle-pp-bon_qqdkrb.png",
+      },
+    ],
+  },
 }
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- add Cloudinary square PNG icon variants to metadata

## Testing
- `pnpm run test` *(fails: Missing script: test)*
- `pnpm lint` *(fails: interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e932df348324b4662b8b25b44fdd