### PR TITLE
Replace pagination with section-based selector

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -5,7 +5,7 @@ import { useState, useRef, useEffect, useCallback } from "react"
 import { Plus, Minus, ChevronLeft, ChevronRight } from "lucide-react"
 import dynamic from "next/dynamic"
 import { Button } from "@/components/ui/button"
-import { Pagination } from "@/components/ui/pagination"
+import { SectionSelector } from "@/components/ui/pagination"
 import { FullScreenButton } from "@/components/fullscreen-button"
 import type { default as FlipBook } from "react-pageflip"
 
@@ -16,6 +16,15 @@ const OPEN_SCALE = 1
 const INITIAL_POS = { x: 0, y: 0 }
 const FLIP_DURATION = 700
 const V_MARGIN = 40
+
+const sections = [
+  { label: "Couverture", page: 1 },
+  { label: "Projet BJÖRN", page: 6 },
+  { label: "Processus de conception", page: 10 },
+  { label: "Site web MBAT", page: 17 },
+  { label: "Contact", page: 20 },
+  { label: "Vidéo", page: 21 },
+]
 
 interface Page {
   id: number
@@ -366,8 +375,8 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
       </Button>
 
       <div className="absolute bottom-4 left-4">
-        <Pagination
-          totalPages={totalPages}
+        <SectionSelector
+          sections={sections}
           currentPage={currentPage + 1}
           goToPage={goToPage}
         />

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -11,20 +11,34 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 
-interface PaginationProps extends React.ComponentProps<"div"> {
-  totalPages: number
+interface SectionSelectorProps extends React.ComponentProps<"div"> {
+  sections: { label: string; page: number }[]
   currentPage: number
   goToPage: (page: number) => void
 }
 
-function Pagination({
-  totalPages,
+function SectionSelector({
+  sections,
   currentPage,
   goToPage,
   className,
   ...props
-}: PaginationProps) {
-  const pages = Array.from({ length: totalPages }, (_, i) => i + 1)
+}: SectionSelectorProps) {
+  const activeSection = React.useMemo(() => {
+    return sections.reduce<{
+      label: string
+      page: number
+    } | undefined>((matched, section) => {
+      if (section.page <= currentPage) {
+        if (!matched || section.page >= matched.page) {
+          return section
+        }
+      }
+      return matched
+    }, undefined)
+  }, [sections, currentPage])
+
+  const value = activeSection ? String(activeSection.page) : undefined
 
   return (
     <div
@@ -32,21 +46,18 @@ function Pagination({
       className={cn("mx-auto flex w-full justify-center", className)}
       {...props}
     >
-      <Select
-        value={String(currentPage)}
-        onValueChange={(value) => goToPage(Number(value))}
-      >
-        <SelectTrigger className="h-9 w-24 bg-white/10 text-white border-none">
-          <SelectValue placeholder={`Page ${currentPage}`} />
+      <Select value={value} onValueChange={(next) => goToPage(Number(next))}>
+        <SelectTrigger className="h-9 min-w-[12rem] border-none bg-white/10 text-white">
+          <SelectValue placeholder="Sélectionner une section" />
         </SelectTrigger>
-        <SelectContent className="bg-white/10 backdrop-blur-sm text-white border-none">
-          {pages.map((page) => (
+        <SelectContent className="border-none bg-white/10 text-white backdrop-blur-sm">
+          {sections.map((section) => (
             <SelectItem
-              key={page}
-              value={String(page)}
+              key={section.page}
+              value={String(section.page)}
               className="text-white focus:bg-white/20"
             >
-              {page}
+              {section.label}
             </SelectItem>
           ))}
         </SelectContent>
@@ -55,5 +66,5 @@ function Pagination({
   )
 }
 
-export { Pagination }
+export { SectionSelector }
 


### PR DESCRIPTION
## Summary
- replace the pagination dropdown with a SectionSelector component driven by named sections
- integrate the SectionSelector into the magazine viewer with the predefined section/page pairs

## Testing
- ⚠️ CI=1 npm run lint *(fails: Next.js `next lint` prompts for initial ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c84424ba2c832485bd85dac962e795