### PR TITLE
Embed YouTube video for portfolio page 27

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -309,7 +309,20 @@ export const portfolioPages = [
   { id: 24, content: <div className="w-full h-full bg-white" /> },
   { id: 25, content: <div className="w-full h-full bg-white" /> },
   { id: 26, content: <div className="w-full h-full bg-white" /> },
-  { id: 27, content: <div className="w-full h-full bg-white" /> },
+  {
+    id: 27,
+    content: (
+      <div className="relative w-full h-full bg-black">
+        <iframe
+          src="https://www.youtube.com/embed/-C9GxSxPXzQ"
+          title="Portfolio flipbook video"
+          allow="autoplay; encrypted-media; picture-in-picture; fullscreen"
+          allowFullScreen
+          className="absolute inset-0 w-full h-full"
+        />
+      </div>
+    ),
+  },
   { id: 28, content: <div className="w-full h-full bg-white" /> },
   { id: 29, content: <div className="w-full h-full bg-white" /> },
   { id: 30, content: <div className="w-full h-full bg-white" /> },


### PR DESCRIPTION
## Summary
- replace the placeholder content for portfolio page 27 with a full-screen black container
- embed the YouTube video so it fills the flipbook page via an iframe that supports fullscreen playback

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8731e8d8832495f157d0b2099f41