### PR TITLE
Fix Eliott spelling in metadata title

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ const openSans = Open_Sans({
 const sora = Sora({ subsets: ["latin"], weight: ["400"], variable: "--font-sora" })
 
 export const metadata: Metadata = {
-  title: "COFFRE Elliott - Portfolio 2025",
+  title: "COFFRE Eliott - Portfolio 2025",
   description:
     "Interactive digital magazine portfolio showcasing branding, packaging, illustration, and web & motion design work.",
   generator: "v0.app",


### PR DESCRIPTION
## Summary
- correct the spelling of Eliott in the site metadata title

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccfb8d24408324bf12f3aa9107ed19