### PR TITLE
Add full-page video trigger to portfolio page 33

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -434,6 +434,27 @@ export const portfolioPages = [
     content: (
       <div className="relative w-full h-full">
         <CloudinaryImage src={page33} alt="Portfolio Page 33" />
+        <VideoModal
+          videoUrl="https://youtu.be/-C9GxSxPXzQ"
+          trigger={
+            <button
+              className="absolute inset-0 flex items-center justify-center bg-transparent hover:bg-black/20 transition-colors"
+              aria-label="Play video"
+            >
+              <svg viewBox="0 0 24 24" className="w-12 h-12 text-white" aria-hidden="true">
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="11"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                />
+                <polygon points="10,8 16,12 10,16" fill="currentColor" />
+              </svg>
+            </button>
+          }
+        />
       </div>
     ),
   },

--- a/components/video-modal.tsx
+++ b/components/video-modal.tsx
@@ -5,16 +5,53 @@ import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog"
 
 interface VideoModalProps {
   trigger: ReactNode
+  /**
+   * A YouTube URL (watch, share or embed) that will be transformed into an embeddable URL.
+   */
+  videoUrl?: string
 }
 
-export function VideoModal({ trigger }: VideoModalProps) {
+const toEmbedUrl = (url: string) => {
+  try {
+    const parsed = new URL(url)
+
+    if (parsed.hostname.includes("youtu.be")) {
+      const videoId = parsed.pathname.replace("/", "")
+      if (videoId) {
+        return `https://www.youtube.com/embed/${videoId}?autoplay=1`
+      }
+    }
+
+    if (parsed.hostname.includes("youtube.com")) {
+      const videoId = parsed.searchParams.get("v")
+      if (videoId) {
+        return `https://www.youtube.com/embed/${videoId}?autoplay=1`
+      }
+
+      if (parsed.pathname.startsWith("/embed/")) {
+        return parsed.search.includes("autoplay=1")
+          ? parsed.toString()
+          : `${parsed.toString()}${parsed.search ? "&" : "?"}autoplay=1`
+      }
+    }
+  } catch (error) {
+    console.warn("Unable to parse video URL", error)
+  }
+
+  return url.includes("autoplay=1") ? url : `${url}${url.includes("?") ? "&" : "?"}autoplay=1`
+}
+
+export function VideoModal({
+  trigger,
+  videoUrl = "https://www.youtube.com/embed/WOCJAxqM7uU?autoplay=1",
+}: VideoModalProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent className="sm:max-w-screen-xl w-full p-0" showCloseButton>
         <div className="aspect-video w-full">
           <iframe
-            src="https://www.youtube.com/embed/WOCJAxqM7uU?autoplay=1"
+            src={toEmbedUrl(videoUrl)}
             title="YouTube video player"
             allow="autoplay; encrypted-media"
             allowFullScreen


### PR DESCRIPTION
## Summary
- allow the shared video modal to accept configurable YouTube URLs by normalizing common link formats
- add a full-page play button overlay on portfolio page 33 that mirrors the styling from page 23 and opens the requested video

## Testing
- pnpm lint *(fails: command prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_69086d0bfc9c8324b854dabe9d617e22