### PR TITLE
Enhance video play icon styling on portfolio page 33

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -443,18 +443,32 @@ export const portfolioPages = [
             >
               <svg
                 viewBox="0 0 24 24"
-                className="w-16 h-16 text-white drop-shadow-[0_6px_12px_rgba(0,0,0,0.45)]"
+                className="w-16 h-16 text-white"
                 aria-hidden="true"
               >
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="11"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                />
-                <polygon points="10,8 16,12 10,16" fill="currentColor" />
+                <defs>
+                  <filter
+                    id="playButtonShadow"
+                    x="-50%"
+                    y="-50%"
+                    width="200%"
+                    height="200%"
+                  >
+                    <feDropShadow dx="0" dy="8" stdDeviation="6" floodOpacity="0.55" />
+                    <feDropShadow dx="0" dy="0" stdDeviation="4" floodOpacity="0.4" />
+                  </filter>
+                </defs>
+                <g filter="url(#playButtonShadow)">
+                  <circle
+                    cx="12"
+                    cy="12"
+                    r="11"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  />
+                  <polygon points="10,8 16,12 10,16" fill="currentColor" />
+                </g>
               </svg>
             </button>
           }

--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -441,7 +441,11 @@ export const portfolioPages = [
               className="absolute inset-0 flex items-center justify-center bg-transparent hover:bg-black/20 transition-colors"
               aria-label="Play video"
             >
-              <svg viewBox="0 0 24 24" className="w-12 h-12 text-white" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                className="w-16 h-16 text-white drop-shadow-[0_6px_12px_rgba(0,0,0,0.45)]"
+                aria-hidden="true"
+              >
                 <circle
                   cx="12"
                   cy="12"


### PR DESCRIPTION
## Summary
- enlarge the play button icon on portfolio page 33 to make it more prominent
- add a drop shadow to the icon for better visual separation from the background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69086ec36aac8324b849c69a69f2431a