### PR TITLE
Add animated GIF overlay to flipbook page 35

### DIFF
--- a/components/Page35Overlay.tsx
+++ b/components/Page35Overlay.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import React from "react";
+
+interface Page35OverlayProps {
+  isTargetPage: boolean;
+}
+
+const GIF_URL =
+  "https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZDN6ZXp1OXZtaW5sMXg1eTRzMXdkc242NHVobmh6Z2ljNmtkdjJkYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/L6J78MhsbfUmPdRl3N/giphy.gif";
+
+export function Page35Overlay({ isTargetPage }: Page35OverlayProps) {
+  if (!isTargetPage) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none"
+      style={{ position: "relative", width: "100%", height: "100%" }}
+    >
+      <img
+        src={GIF_URL}
+        alt="gif"
+        draggable={false}
+        style={{
+          position: "absolute",
+          left: "268px",
+          bottom: "840px",
+          width: "2050px",
+          height: "1170px",
+          objectFit: "cover",
+          zIndex: 5,
+          pointerEvents: "none",
+        }}
+      />
+    </div>
+  );
+}
+
+export default Page35Overlay;

--- a/components/ResponsiveFlipBook.tsx
+++ b/components/ResponsiveFlipBook.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 
+import Page35Overlay from "./Page35Overlay";
+
 // react-pageflip doit être chargé uniquement côté client
 const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false });
 
@@ -61,12 +63,24 @@ export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveF
       >
         {pages.map((src, index) => (
           <div key={index} className="w-full h-full">
-            <img
-              src={src}
-              alt={`page-${index + 1}`}
-              className="w-full h-full object-cover"
-              draggable={false}
-            />
+            {index === 34 ? (
+              <div className="relative w-full h-full">
+                <img
+                  src={src}
+                  alt={`page-${index + 1}`}
+                  className="w-full h-full object-cover"
+                  draggable={false}
+                />
+                <Page35Overlay isTargetPage />
+              </div>
+            ) : (
+              <img
+                src={src}
+                alt={`page-${index + 1}`}
+                className="w-full h-full object-cover"
+                draggable={false}
+              />
+            )}
           </div>
         ))}
       </HTMLFlipBook>


### PR DESCRIPTION
## Summary
- add a Page35Overlay client component that renders the required GIF with fixed positioning
- wrap flipbook page 35 content in a relative container and mount the overlay above the page image

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69087ee7aa4c83248c98a859eaecec2c