### PR TITLE
Add animated overlay to portfolio page 35

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -489,6 +489,14 @@ export const portfolioPages = [
     content: (
       <div className="relative w-full h-full">
         <CloudinaryImage src={page35} alt="Portfolio Page 35" />
+        <img
+          src="https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZDN6ZXp1OXZtaW5sMXg1eTRzMXdkc242NHVobmh6Z2ljNmtkdjJkYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/L6J78MhsbfUmPdRl3N/giphy.gif"
+          alt="Animation illustrant le projet"
+          width={2050}
+          height={1170}
+          className="absolute"
+          style={{ left: "268px", bottom: "840px" }}
+        />
       </div>
     ),
   },


### PR DESCRIPTION
## Summary
- overlay the new GIF on portfolio page 35 above the existing Cloudinary image
- position the animation at the requested size and offsets so it sits 840px from the bottom and 268px from the left

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908823cc68c8324b645fe5f893e4e70