### PR TITLE
Add GIF overlay to portfolio page 35

### DIFF
--- a/components/portfolio-pages.tsx
+++ b/components/portfolio-pages.tsx
@@ -489,6 +489,17 @@ export const portfolioPages = [
     content: (
       <div className="relative w-full h-full">
         <CloudinaryImage src={page35} alt="Portfolio Page 35" />
+        <img
+          src="https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZDN6ZXp1OXZtaW5sMXg1eTRzMXdkc242NHVobmh6Z2ljNmtkdjJkYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/L6J78MhsbfUmPdRl3N/giphy.gif"
+          alt="Animated scene for portfolio page 35"
+          className="absolute object-cover"
+          style={{
+            left: "10.8%",
+            bottom: "23.94%",
+            width: "82.66%",
+            height: "33.37%",
+          }}
+        />
       </div>
     ),
   },


### PR DESCRIPTION
## Summary
- overlay the requested GIF onto portfolio page 35 with the specified placement and scale

## Testing
- not run (npm run lint prompts for initial ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_69088c4412948324a99b06361038772b