### PR TITLE
Add depth styling to magazine floating controls

### DIFF
--- a/components/fullscreen-button.tsx
+++ b/components/fullscreen-button.tsx
@@ -38,7 +38,7 @@ export function FullScreenButton() {
         variant="ghost"
         size="icon"
         onClick={toggleFullscreen}
-        className="bg-transparent hover:bg-white/10 text-white/70 hover:text-white border-none w-16 h-16 transition-all duration-300"
+        className="bg-slate-900/40 text-white hover:bg-slate-900/60 hover:text-white dark:bg-white/20 dark:hover:bg-white/30 dark:text-white w-16 h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
       >
         {isFullscreen ? (
           <Minimize2 className="h-8 w-8" />

--- a/components/fullscreen-button.tsx
+++ b/components/fullscreen-button.tsx
@@ -38,7 +38,7 @@ export function FullScreenButton() {
         variant="ghost"
         size="icon"
         onClick={toggleFullscreen}
-        className="bg-slate-900/40 text-white hover:bg-slate-900/60 hover:text-white dark:bg-white/20 dark:hover:bg-white/30 dark:text-white w-16 h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
+        className="bg-slate-900/30 text-white hover:bg-slate-900/20 hover:text-white dark:bg-white/15 dark:hover:bg-white/25 dark:text-white w-16 h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
       >
         {isFullscreen ? (
           <Minimize2 className="h-8 w-8" />

--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -405,7 +405,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         variant="ghost"
         size="icon"
         onClick={handlePrevPage}
-        className="absolute top-1/2 left-4 -translate-y-1/2 bg-slate-900/40 text-white hover:bg-slate-900/60 hover:text-white dark:bg-white/20 dark:hover:bg-white/30 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
+        className="absolute top-1/2 left-4 -translate-y-1/2 bg-slate-900/30 text-white hover:bg-slate-900/20 hover:text-white dark:bg-white/15 dark:hover:bg-white/25 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
       >
         <ChevronLeft className="h-8 w-8" />
       </Button>
@@ -413,7 +413,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         variant="ghost"
         size="icon"
         onClick={handleNextPage}
-        className="absolute top-1/2 right-4 -translate-y-1/2 bg-slate-900/40 text-white hover:bg-slate-900/60 hover:text-white dark:bg-white/20 dark:hover:bg-white/30 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
+        className="absolute top-1/2 right-4 -translate-y-1/2 bg-slate-900/30 text-white hover:bg-slate-900/20 hover:text-white dark:bg-white/15 dark:hover:bg-white/25 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
       >
         <ChevronRight className="h-8 w-8" />
       </Button>
@@ -431,7 +431,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
           variant="ghost"
           size="icon"
           onClick={zoomIn}
-          className="bg-slate-900/40 text-white hover:bg-slate-900/60 hover:text-white dark:bg-white/20 dark:hover:bg-white/30 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
+          className="bg-slate-900/30 text-white hover:bg-slate-900/20 hover:text-white dark:bg-white/15 dark:hover:bg-white/25 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
         >
           <Plus className="h-8 w-8" />
         </Button>
@@ -439,7 +439,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
           variant="ghost"
           size="icon"
           onClick={zoomOut}
-          className="bg-slate-900/40 text-white hover:bg-slate-900/60 hover:text-white dark:bg-white/20 dark:hover:bg-white/30 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
+          className="bg-slate-900/30 text-white hover:bg-slate-900/20 hover:text-white dark:bg-white/15 dark:hover:bg-white/25 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
         >
           <Minus className="h-8 w-8" />
         </Button>

--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -405,7 +405,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         variant="ghost"
         size="icon"
         onClick={handlePrevPage}
-        className="absolute top-1/2 left-4 -translate-y-1/2 bg-transparent hover:bg-white/10 text-white/70 hover:text-white border-none w-12 h-12 md:w-16 md:h-16 transition-all duration-300"
+        className="absolute top-1/2 left-4 -translate-y-1/2 bg-slate-900/40 text-white hover:bg-slate-900/60 hover:text-white dark:bg-white/20 dark:hover:bg-white/30 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
       >
         <ChevronLeft className="h-8 w-8" />
       </Button>
@@ -413,7 +413,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         variant="ghost"
         size="icon"
         onClick={handleNextPage}
-        className="absolute top-1/2 right-4 -translate-y-1/2 bg-transparent hover:bg-white/10 text-white/70 hover:text-white border-none w-12 h-12 md:w-16 md:h-16 transition-all duration-300"
+        className="absolute top-1/2 right-4 -translate-y-1/2 bg-slate-900/40 text-white hover:bg-slate-900/60 hover:text-white dark:bg-white/20 dark:hover:bg-white/30 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
       >
         <ChevronRight className="h-8 w-8" />
       </Button>
@@ -431,7 +431,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
           variant="ghost"
           size="icon"
           onClick={zoomIn}
-          className="bg-transparent hover:bg-white/10 text-white/70 hover:text-white border-none w-12 h-12 md:w-16 md:h-16 transition-all duration-300"
+          className="bg-slate-900/40 text-white hover:bg-slate-900/60 hover:text-white dark:bg-white/20 dark:hover:bg-white/30 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
         >
           <Plus className="h-8 w-8" />
         </Button>
@@ -439,7 +439,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
           variant="ghost"
           size="icon"
           onClick={zoomOut}
-          className="bg-transparent hover:bg-white/10 text-white/70 hover:text-white border-none w-12 h-12 md:w-16 md:h-16 transition-all duration-300"
+          className="bg-slate-900/40 text-white hover:bg-slate-900/60 hover:text-white dark:bg-white/20 dark:hover:bg-white/30 dark:text-white w-12 h-12 md:w-16 md:h-16 transition-all duration-300 backdrop-blur-sm shadow-lg ring-1 ring-black/10 dark:ring-white/20"
         >
           <Minus className="h-8 w-8" />
         </Button>


### PR DESCRIPTION
## Summary
- add translucent backdrop, ring, and shadow styles to magazine navigation buttons for better readability
- align fullscreen toggle styling with magazine controls for consistent floating button appearance

## Testing
- pnpm lint *(fails: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6908a58238488324a5ed0bd822dc225b