### PR TITLE
Adjust flipbook page shadows for balanced lighting

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -199,7 +199,37 @@
 
 /* Custom flipbook page styling */
 .flipbook .stf__item {
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+  position: relative;
+  box-shadow: none;
+}
+
+.flipbook .stf__item::before,
+.flipbook .stf__item::after {
+  content: "";
+  position: absolute;
+  top: 6%;
+  bottom: 6%;
+  width: 40px;
+  pointer-events: none;
+  transition: opacity var(--flip-duration, 700ms) ease;
+}
+
+.flipbook .stf__item::before {
+  left: 0;
+  background: linear-gradient(
+    to right,
+    rgba(0, 0, 0, 0.18),
+    rgba(0, 0, 0, 0)
+  );
+}
+
+.flipbook .stf__item::after {
+  right: 0;
+  background: linear-gradient(
+    to left,
+    rgba(0, 0, 0, 0.25),
+    rgba(0, 0, 0, 0)
+  );
 }
 
 .flipbook .stf__item > div {


### PR DESCRIPTION
## Summary
- replace the flipbook page box-shadow with pseudo-element gradients so each side can be tuned independently
- reduce the left edge shading while adding a mirrored right edge shadow to maintain visual depth during page turns

## Testing
- not run (manual visual verification recommended)


------
https://chatgpt.com/codex/tasks/task_e_6908a5858ae883249734c8ebc33ea9c0