### PR TITLE
Disable page corner hover on flipbook

### DIFF
--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -367,7 +367,7 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
         maxShadowOpacity={0.2}
         drawShadow
         flippingTime={FLIP_DURATION}
-        showPageCorners
+        showPageCorners={false}
         disableFlipByClick
         swipeDistance={30}
         className="shadow-md flipbook"


### PR DESCRIPTION
## Summary
- disable the HTMLFlipBook page corner hover effect to remove the fold preview

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908a5893efc832482b29b40f3dd080f