### PR TITLE
Enable wrap-around flipbook navigation

### DIFF
--- a/components/ResponsiveFlipBook.tsx
+++ b/components/ResponsiveFlipBook.tsx
@@ -6,6 +6,8 @@ import dynamic from "next/dynamic";
 // react-pageflip doit être chargé uniquement côté client
 const HTMLFlipBook = dynamic(() => import("react-pageflip"), { ssr: false });
 
+const WRAP_SPIN_DURATION = 600;
+
 export interface ResponsiveFlipBookProps {
   pages: string[];
   ratio?: number; // ratio largeur/hauteur d'une page
@@ -13,11 +15,14 @@ export interface ResponsiveFlipBookProps {
 
 export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveFlipBookProps) {
   const bookRef = useRef<any>(null);
+  const wrapTimeoutRef = useRef<number | null>(null);
   const totalPages = pages.length;
   const [size, setSize] = useState({
     pageWidth: 0,
     pageHeight: 0,
   });
+  const [wrapDirection, setWrapDirection] = useState<"forward" | "backward" | null>(null);
+  const isWrapping = wrapDirection !== null;
 
   // calcul dynamique du responsive
   useEffect(() => {
@@ -42,68 +47,58 @@ export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveF
     return () => window.removeEventListener("resize", updateSize);
   }, [ratio]);
 
+  useEffect(() => {
+    return () => {
+      if (wrapTimeoutRef.current != null) {
+        window.clearTimeout(wrapTimeoutRef.current);
+        wrapTimeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  const triggerWrapRotation = (targetIndex: number, direction: "forward" | "backward") => {
+    const flip = bookRef.current?.pageFlip?.();
+    if (!flip) return;
+
+    setWrapDirection(direction);
+
+    requestAnimationFrame(() => {
+      flip.turnToPage?.(targetIndex);
+    });
+
+    if (wrapTimeoutRef.current != null) {
+      window.clearTimeout(wrapTimeoutRef.current);
+    }
+
+    wrapTimeoutRef.current = window.setTimeout(() => {
+      setWrapDirection(null);
+      wrapTimeoutRef.current = null;
+    }, WRAP_SPIN_DURATION);
+  };
+
   const handleNextPage = () => {
+    if (isWrapping) return;
+
     const flip = bookRef.current?.pageFlip?.();
     if (!flip || totalPages <= 1) return;
 
     const currentIndex = flip.getCurrentPageIndex?.() ?? 0;
     if (currentIndex >= totalPages - 1) {
-      const anyFlip = flip as any;
-      const controller = anyFlip?.getFlipController?.();
-      const collection = anyFlip?.getPageCollection?.();
-
-      if (
-        controller &&
-        collection &&
-        typeof collection.currentSpreadIndex === "number" &&
-        typeof collection.currentPageIndex === "number"
-      ) {
-        collection.currentSpreadIndex = -1;
-        collection.currentPageIndex = -1;
-        controller.flipNext?.("top");
-      } else {
-        flip.flip?.(0);
-      }
+      triggerWrapRotation(0, "forward");
     } else {
       flip.flipNext?.();
     }
   };
 
   const handlePrevPage = () => {
+    if (isWrapping) return;
+
     const flip = bookRef.current?.pageFlip?.();
     if (!flip || totalPages <= 1) return;
 
     const currentIndex = flip.getCurrentPageIndex?.() ?? 0;
     if (currentIndex <= 0) {
-      const anyFlip = flip as any;
-      const controller = anyFlip?.getFlipController?.();
-      const collection = anyFlip?.getPageCollection?.();
-      const lastPageIndex = totalPages - 1;
-      const lastSpreadIndex = collection?.getSpreadIndexByPage?.(lastPageIndex);
-
-      if (
-        controller &&
-        collection &&
-        typeof collection.currentSpreadIndex === "number" &&
-        typeof collection.currentPageIndex === "number"
-      ) {
-        const wrapIndex =
-          typeof lastSpreadIndex === "number"
-            ? lastSpreadIndex + 1
-            : collection.currentSpreadIndex + 1;
-
-        const normalizedWrapIndex = Math.floor(wrapIndex);
-
-        if (Number.isFinite(normalizedWrapIndex)) {
-          collection.currentSpreadIndex = normalizedWrapIndex;
-          collection.currentPageIndex = Math.max(lastPageIndex + 1, 1);
-          controller.flipPrev?.("top");
-        } else {
-          flip.flip?.(lastPageIndex);
-        }
-      } else {
-        flip.flip?.(lastPageIndex);
-      }
+      triggerWrapRotation(totalPages - 1, "backward");
     } else {
       flip.flipPrev?.();
     }
@@ -111,33 +106,51 @@ export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveF
 
   if (!size.pageWidth) return null;
 
+  const rotationClass = wrapDirection
+    ? wrapDirection === "forward"
+      ? "flipbook-spin-forward"
+      : "flipbook-spin-backward"
+    : "";
+
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black">
-      <HTMLFlipBook
-        ref={bookRef}
-        key={`${size.pageWidth}x${size.pageHeight}`} // force re-render au resize
-        width={size.pageWidth}
-        height={size.pageHeight}
-        size="fixed"
-        minWidth={200}
-        maxWidth={3000}
-        minHeight={200}
-        maxHeight={4000}
-        showCover={true}
-        usePortrait={false} // 🚀 force toujours double page
-        className="shadow-2xl"
+    <div
+      className="fixed inset-0 flex items-center justify-center bg-black"
+      style={{ perspective: "2000px" }}
+    >
+      <div
+        className={`flipbook-rotate-wrapper ${rotationClass}`.trim()}
+        style={
+          wrapDirection
+            ? { animationDuration: `${WRAP_SPIN_DURATION}ms` }
+            : undefined
+        }
       >
-        {pages.map((src, index) => (
-          <div key={index} className="w-full h-full">
-            <img
-              src={src}
-              alt={`page-${index + 1}`}
-              className="w-full h-full object-cover"
-              draggable={false}
-            />
-          </div>
-        ))}
-      </HTMLFlipBook>
+        <HTMLFlipBook
+          ref={bookRef}
+          key={`${size.pageWidth}x${size.pageHeight}`} // force re-render au resize
+          width={size.pageWidth}
+          height={size.pageHeight}
+          size="fixed"
+          minWidth={200}
+          maxWidth={3000}
+          minHeight={200}
+          maxHeight={4000}
+          showCover={true}
+          usePortrait={false} // 🚀 force toujours double page
+          className="shadow-2xl"
+        >
+          {pages.map((src, index) => (
+            <div key={index} className="w-full h-full">
+              <img
+                src={src}
+                alt={`page-${index + 1}`}
+                className="w-full h-full object-cover"
+                draggable={false}
+              />
+            </div>
+          ))}
+        </HTMLFlipBook>
+      </div>
 
       {/* Boutons navigation */}
       <button

--- a/components/ResponsiveFlipBook.tsx
+++ b/components/ResponsiveFlipBook.tsx
@@ -13,6 +13,7 @@ export interface ResponsiveFlipBookProps {
 
 export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveFlipBookProps) {
   const bookRef = useRef<any>(null);
+  const totalPages = pages.length;
   const [size, setSize] = useState({
     pageWidth: 0,
     pageHeight: 0,
@@ -40,6 +41,30 @@ export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveF
     window.addEventListener("resize", updateSize);
     return () => window.removeEventListener("resize", updateSize);
   }, [ratio]);
+
+  const handleNextPage = () => {
+    const flip = bookRef.current?.pageFlip?.();
+    if (!flip || totalPages === 0) return;
+
+    const currentIndex = flip.getCurrentPageIndex?.() ?? 0;
+    if (currentIndex >= totalPages - 1) {
+      flip.flip?.(0);
+    } else {
+      flip.flipNext?.();
+    }
+  };
+
+  const handlePrevPage = () => {
+    const flip = bookRef.current?.pageFlip?.();
+    if (!flip || totalPages === 0) return;
+
+    const currentIndex = flip.getCurrentPageIndex?.() ?? 0;
+    if (currentIndex <= 0) {
+      flip.flip?.(totalPages - 1);
+    } else {
+      flip.flipPrev?.();
+    }
+  };
 
   if (!size.pageWidth) return null;
 
@@ -73,13 +98,13 @@ export default function ResponsiveFlipBook({ pages, ratio = 0.707 }: ResponsiveF
 
       {/* Boutons navigation */}
       <button
-        onClick={() => bookRef.current?.pageFlip().flipPrev()}
+        onClick={handlePrevPage}
         className="absolute left-4 top-1/2 -translate-y-1/2 bg-black/60 text-white px-3 py-1 rounded"
       >
         ◀
       </button>
       <button
-        onClick={() => bookRef.current?.pageFlip().flipNext()}
+        onClick={handleNextPage}
         className="absolute right-4 top-1/2 -translate-y-1/2 bg-black/60 text-white px-3 py-1 rounded"
       >
         ▶

--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -128,11 +128,27 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
   }, [])
 
   const handleNextPage = () => {
-    bookRef.current?.pageFlip()?.flipNext()
+    const flip = bookRef.current?.pageFlip?.()
+    if (!flip || totalPages === 0) return
+
+    const currentIndex = flip.getCurrentPageIndex?.() ?? currentPage
+    if (currentIndex >= totalPages - 1) {
+      flip.flip?.(0)
+    } else {
+      flip.flipNext?.()
+    }
   }
 
   const handlePrevPage = () => {
-    bookRef.current?.pageFlip()?.flipPrev()
+    const flip = bookRef.current?.pageFlip?.()
+    if (!flip || totalPages === 0) return
+
+    const currentIndex = flip.getCurrentPageIndex?.() ?? currentPage
+    if (currentIndex <= 0) {
+      flip.flip?.(totalPages - 1)
+    } else {
+      flip.flipPrev?.()
+    }
   }
 
   const goToPage = (page: number) => {

--- a/components/magazine-viewer.tsx
+++ b/components/magazine-viewer.tsx
@@ -129,11 +129,26 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
 
   const handleNextPage = () => {
     const flip = bookRef.current?.pageFlip?.()
-    if (!flip || totalPages === 0) return
+    if (!flip || totalPages <= 1) return
 
     const currentIndex = flip.getCurrentPageIndex?.() ?? currentPage
     if (currentIndex >= totalPages - 1) {
-      flip.flip?.(0)
+      const anyFlip = flip as any
+      const controller = anyFlip?.getFlipController?.()
+      const collection = anyFlip?.getPageCollection?.()
+
+      if (
+        controller &&
+        collection &&
+        typeof collection.currentSpreadIndex === "number" &&
+        typeof collection.currentPageIndex === "number"
+      ) {
+        collection.currentSpreadIndex = -1
+        collection.currentPageIndex = -1
+        controller.flipNext?.("top")
+      } else {
+        flip.flip?.(0)
+      }
     } else {
       flip.flipNext?.()
     }
@@ -141,11 +156,39 @@ export function MagazineViewer({ pages }: MagazineViewerProps) {
 
   const handlePrevPage = () => {
     const flip = bookRef.current?.pageFlip?.()
-    if (!flip || totalPages === 0) return
+    if (!flip || totalPages <= 1) return
 
     const currentIndex = flip.getCurrentPageIndex?.() ?? currentPage
     if (currentIndex <= 0) {
-      flip.flip?.(totalPages - 1)
+      const anyFlip = flip as any
+      const controller = anyFlip?.getFlipController?.()
+      const collection = anyFlip?.getPageCollection?.()
+      const lastPageIndex = totalPages - 1
+      const lastSpreadIndex = collection?.getSpreadIndexByPage?.(lastPageIndex)
+
+      if (
+        controller &&
+        collection &&
+        typeof collection.currentSpreadIndex === "number" &&
+        typeof collection.currentPageIndex === "number"
+      ) {
+        const wrapIndex =
+          typeof lastSpreadIndex === "number"
+            ? lastSpreadIndex + 1
+            : collection.currentSpreadIndex + 1
+
+        const normalizedWrapIndex = Math.floor(wrapIndex)
+
+        if (Number.isFinite(normalizedWrapIndex)) {
+          collection.currentSpreadIndex = normalizedWrapIndex
+          collection.currentPageIndex = Math.max(lastPageIndex + 1, 1)
+          controller.flipPrev?.("top")
+        } else {
+          flip.flip?.(lastPageIndex)
+        }
+      } else {
+        flip.flip?.(lastPageIndex)
+      }
     } else {
       flip.flipPrev?.()
     }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -121,3 +121,49 @@
     @apply bg-background text-foreground;
   }
 }
+
+.flipbook-transform-wrapper {
+  position: relative;
+  transform-style: preserve-3d;
+  will-change: transform;
+}
+
+.flipbook-rotate-wrapper {
+  position: relative;
+  transform-style: preserve-3d;
+  will-change: transform;
+  backface-visibility: hidden;
+}
+
+.flipbook-spin-forward,
+.flipbook-spin-backward {
+  animation-fill-mode: forwards;
+  transform-style: preserve-3d;
+  animation-timing-function: ease-in-out;
+}
+
+.flipbook-spin-forward {
+  animation-name: flipbook-spin-forward;
+}
+
+.flipbook-spin-backward {
+  animation-name: flipbook-spin-backward;
+}
+
+@keyframes flipbook-spin-forward {
+  from {
+    transform: rotateY(0deg);
+  }
+  to {
+    transform: rotateY(360deg);
+  }
+}
+
+@keyframes flipbook-spin-backward {
+  from {
+    transform: rotateY(0deg);
+  }
+  to {
+    transform: rotateY(-360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- update both flipbook components to detect the current page from the flip instance
- loop the next and previous controls so navigation wraps between the first and last pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908b22b9a708324b016a9fdaad9a5c8